### PR TITLE
Change the PHPUnit workdir

### DIFF
--- a/5.2/phpunit/Dockerfile
+++ b/5.2/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:5.2-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-3.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/5.3/phpunit/Dockerfile
+++ b/5.3/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:5.3-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-4.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/5.4/phpunit/Dockerfile
+++ b/5.4/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:5.4-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-4.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/5.5/phpunit/Dockerfile
+++ b/5.5/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:5.5-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-4.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/5.6/phpunit/Dockerfile
+++ b/5.6/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:5.6-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-5.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/7.0/phpunit/Dockerfile
+++ b/7.0/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:7.0-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-6.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/7.1/phpunit/Dockerfile
+++ b/7.1/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:7.1-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/7.2/phpunit/Dockerfile
+++ b/7.2/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:7.2-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/7.3/phpunit/Dockerfile
+++ b/7.3/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:7.3-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/7.4/phpunit/Dockerfile
+++ b/7.4/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:7.4-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/8.0/phpunit/Dockerfile
+++ b/8.0/phpunit/Dockerfile
@@ -10,6 +10,6 @@ FROM $PACKAGE_REGISTRY/php:8.0-fpm$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit

--- a/Dockerfile-phpunit.template
+++ b/Dockerfile-phpunit.template
@@ -6,6 +6,6 @@ FROM $PACKAGE_REGISTRY/php:%%VERSION_TAG%%$PR_TAG
 
 RUN curl -sL https://phar.phpunit.de/phpunit-%%PHPUNIT_VERSION%%.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
-WORKDIR /wordpress-develop
+WORKDIR /var/www
 
 CMD /usr/local/bin/phpunit


### PR DESCRIPTION
This changes the PHPUnit image `WORKDIR` from `/wordpress-develop` to `/var/www`, bringing it into line with all of the other images. 