### PR TITLE
Dynamically change UID and GID of PHP-FPM process

### DIFF
--- a/5.2/php/Dockerfile
+++ b/5.2/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -25,7 +25,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.2/php/Dockerfile
+++ b/5.2/php/Dockerfile
@@ -11,11 +11,21 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.2/php/entrypoint.sh
+++ b/5.2/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/5.2/php/entrypoint.sh
+++ b/5.2/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/5.2/php/php-fpm.conf
+++ b/5.2/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/5.3/php/Dockerfile
+++ b/5.3/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -34,8 +41,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.3/php/Dockerfile
+++ b/5.3/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -45,7 +45,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.3/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.3/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/5.3/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.3/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/5.3/php/entrypoint.sh
+++ b/5.3/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/5.3/php/entrypoint.sh
+++ b/5.3/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/5.3/php/php-fpm.conf
+++ b/5.3/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/5.4/php/Dockerfile
+++ b/5.4/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.4/php/Dockerfile
+++ b/5.4/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.4/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.4/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/5.4/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.4/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/5.4/php/entrypoint.sh
+++ b/5.4/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/5.4/php/entrypoint.sh
+++ b/5.4/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/5.4/php/php-fpm.conf
+++ b/5.4/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/5.5/php/Dockerfile
+++ b/5.5/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.5/php/Dockerfile
+++ b/5.5/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.5/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.5/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/5.5/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.5/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/5.5/php/entrypoint.sh
+++ b/5.5/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/5.5/php/entrypoint.sh
+++ b/5.5/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/5.5/php/php-fpm.conf
+++ b/5.5/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/5.6/php/Dockerfile
+++ b/5.6/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.6/php/Dockerfile
+++ b/5.6/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/5.6/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.6/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/5.6/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/5.6/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/5.6/php/entrypoint.sh
+++ b/5.6/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/5.6/php/entrypoint.sh
+++ b/5.6/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/5.6/php/php-fpm.conf
+++ b/5.6/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/7.0/php/Dockerfile
+++ b/7.0/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.0/php/Dockerfile
+++ b/7.0/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.0/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.0/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/7.0/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.0/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/7.0/php/entrypoint.sh
+++ b/7.0/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/7.0/php/entrypoint.sh
+++ b/7.0/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/7.0/php/php-fpm.conf
+++ b/7.0/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/7.1/php/Dockerfile
+++ b/7.1/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.1/php/Dockerfile
+++ b/7.1/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.1/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.1/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/7.1/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.1/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/7.1/php/entrypoint.sh
+++ b/7.1/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/7.1/php/entrypoint.sh
+++ b/7.1/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/7.1/php/php-fpm.conf
+++ b/7.1/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/7.2/php/Dockerfile
+++ b/7.2/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.2/php/Dockerfile
+++ b/7.2/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.2/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.2/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/7.2/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.2/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/7.2/php/entrypoint.sh
+++ b/7.2/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/7.2/php/entrypoint.sh
+++ b/7.2/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/7.2/php/php-fpm.conf
+++ b/7.2/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/7.3/php/Dockerfile
+++ b/7.3/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.3/php/Dockerfile
+++ b/7.3/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.3/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.3/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/7.3/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.3/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/7.3/php/entrypoint.sh
+++ b/7.3/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/7.3/php/entrypoint.sh
+++ b/7.3/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/7.3/php/php-fpm.conf
+++ b/7.3/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/7.4/php/Dockerfile
+++ b/7.4/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -56,7 +56,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.4/php/Dockerfile
+++ b/7.4/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -45,8 +52,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/7.4/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.4/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/7.4/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/7.4/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/7.4/php/entrypoint.sh
+++ b/7.4/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/7.4/php/entrypoint.sh
+++ b/7.4/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/7.4/php/php-fpm.conf
+++ b/7.4/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/8.0/php/Dockerfile
+++ b/8.0/php/Dockerfile
@@ -11,10 +11,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -47,7 +47,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/8.0/php/Dockerfile
+++ b/8.0/php/Dockerfile
@@ -11,6 +11,13 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 # install the PHP extensions we need
 RUN set -ex; \
 	\
@@ -36,8 +43,11 @@ RUN set -ex; \
 	rm -f /tmp/installer.php /tmp/installer.sig;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/8.0/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/8.0/php/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user and group
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/8.0/php/docker-entrypoint.d/100-uid-gid.sh
+++ b/8.0/php/docker-entrypoint.d/100-uid-gid.sh
@@ -76,7 +76,7 @@ set_uid() {
                 log "warn" "User with ${uid} already exists: ${target_username}"
                 usermod -u "${spare_uid}" "${target_username}"
             fi
-        # UID not found, let's create a new user and group
+        # UID not found, let's create a new user
         else
             useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
             return 0
@@ -107,6 +107,7 @@ set_gid() {
                 log "warn" "Group with ${gid} already exists: ${target_groupname}"
                 groupmod -g "${spare_gid}" "${target_groupname}"
             fi
+        # GID not found, let's create a new group
         else
             groupadd -g "${gid}" -r "${groupname}"
             return 0

--- a/8.0/php/entrypoint.sh
+++ b/8.0/php/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/8.0/php/entrypoint.sh
+++ b/8.0/php/entrypoint.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/8.0/php/php-fpm.conf
+++ b/8.0/php/php-fpm.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/Dockerfile-php.template
+++ b/Dockerfile-php.template
@@ -7,10 +7,10 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
-# Update the user/group in "php-fpm.conf" if
-# PHP_FPM_USER or PHP_FPM_GROUP is changed
-ENV PHP_FPM_USER wp_php
-ENV	PHP_FPM_GROUP wp_php
+# Update the user/group in "php-fpm.conf" and "entrypoint-php.sh"
+# if PHP_FPM_USER or PHP_FPM_GROUP is changed
+ARG PHP_FPM_USER wp_php
+ARG	PHP_FPM_GROUP wp_php
 ENV	PHP_FPM_UID 1000
 ENV	PHP_FPM_GID 1000
 
@@ -21,7 +21,9 @@ COPY docker-entrypoint.d /docker-entrypoint.d
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
 RUN chmod +x /entrypoint.sh && \
-    chmod +x /docker-entrypoint.d/*.sh
+    chmod +x /docker-entrypoint.d/*.sh && \
+    groupadd -g ${PHP_FPM_GID} -r ${PHP_FPM_GROUP} && \
+    useradd -M -u ${PHP_FPM_UID} -s /bin/bash -g ${PHP_FPM_GROUP} ${PHP_FPM_USER}
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/Dockerfile-php.template
+++ b/Dockerfile-php.template
@@ -7,11 +7,21 @@ WORKDIR /var/www
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV COMPOSER_HOME /tmp
 
+# Update the user/group in "php-fpm.conf" if
+# PHP_FPM_USER or PHP_FPM_GROUP is changed
+ENV PHP_FPM_USER wp_php
+ENV	PHP_FPM_GROUP wp_php
+ENV	PHP_FPM_UID 1000
+ENV	PHP_FPM_GID 1000
+
 %%INSTALL_EXTENSIONS%%
 
 COPY entrypoint.sh /entrypoint.sh
+COPY docker-entrypoint.d /docker-entrypoint.d
+COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && \
+    chmod +x /docker-entrypoint.d/*.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/docker-entrypoint.d/100-uid-gid.sh
+++ b/docker-entrypoint.d/100-uid-gid.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -e
+
+
+############################################################
+# Functions
+############################################################
+
+###
+### Log to stdout/stderr
+###
+log() {
+    local type="${1}"     # ok, warn or err
+    local message="${2}"  # msg to print
+
+    local clr_ok="\033[0;32m"
+    local clr_info="\033[0;34m"
+    local clr_warn="\033[0;33m"
+    local clr_err="\033[0;31m"
+    local clr_rst="\033[0m"
+
+    if [ "${type}" = "warn" ]; then
+        printf "${clr_warn}[WARN] %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    elif [ "${type}" = "err" ]; then
+        printf "${clr_err}[ERR]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    else
+        printf "${clr_err}[???]  %s${clr_rst}\n" "${message}" 1>&2	# stdout -> stderr
+    fi
+}
+
+###
+### Is argument a positive integer?
+###
+isint() {
+	test -n "${1##*[!0-9]*}"
+}
+
+###
+### Helper
+###
+_get_username_by_uid() {
+    if getent="$( getent passwd "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+_get_groupname_by_gid() {
+    if getent="$( getent group "${1}" )"; then
+        echo "${getent//:*}"
+        return 0
+    fi
+    return 1
+}
+
+
+###
+### Change UID
+###
+set_uid() {
+    local uid="${1}"
+    local username="${2}"
+    local groupname="${3}"
+
+    # spare UID to change another user to
+    local spare_uid=9876
+
+    if ! isint "${uid}"; then
+        log "err" "${uid} is not a valid UID"
+        exit 1
+    else
+        # Username with this UID already exists
+        if target_username="$( _get_username_by_uid "${uid}" )"; then
+            # It is not our user, so we need to change their UID to something else first
+            if [ "${target_username}" != "${username}" ]; then
+                log "warn" "User with ${uid} already exists: ${target_username}"
+                usermod -u "${spare_uid}" "${target_username}"
+            fi
+        # UID not found, let's create a new user
+        else
+            useradd -M -u "${uid}" -s /bin/bash -g "${groupname}" "${username}"
+            return 0
+        fi
+        usermod -u "${uid}" "${username}"
+    fi
+}
+
+
+###
+### Change GID
+###
+set_gid() {
+    local gid="${1}"
+    local groupname="${2}"
+
+    # spare GID to change another group to
+    local spare_gid=9876
+
+    if ! isint "${gid}"; then
+        log "err" "${gid} is not a valid GID"
+        exit 1
+    else
+        # Groupname with this GID already exists
+        if target_groupname="$( _get_groupname_by_gid "${gid}" )"; then
+            # It is not our group, so we need to change their GID to something else first
+            if [ "${target_groupname}" != "${groupname}" ]; then
+                log "warn" "Group with ${gid} already exists: ${target_groupname}"
+                groupmod -g "${spare_gid}" "${target_groupname}"
+            fi
+        # GID not found, let's create a new group
+        else
+            groupadd -g "${gid}" -r "${groupname}"
+            return 0
+        fi
+        groupmod -g "${gid}" "${groupname}"
+    fi
+}

--- a/entrypoint-php.sh
+++ b/entrypoint-php.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+source /docker-entrypoint.d/100-uid-gid.sh
+
 # If LOCAL_PHP_XDEBUG=true xdebug extension will be enabled
 if [ "$LOCAL_PHP_XDEBUG" = true ]; then
 	docker-php-ext-enable xdebug
@@ -16,6 +18,11 @@ if [ "$LOCAL_PHP_MEMCACHED" = true ]; then
 else
 	rm -f /usr/local/etc/php/conf.d/docker-php-ext-memcached.ini
 fi
+
+
+### Change UID/GID
+set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
+set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
 
 # Execute CMD
 exec "$@"

--- a/entrypoint-php.sh
+++ b/entrypoint-php.sh
@@ -21,8 +21,8 @@ fi
 
 
 ### Change UID/GID
-set_gid "${PHP_FPM_GID}" "${PHP_FPM_GROUP}"
-set_uid "${PHP_FPM_UID}" "${PHP_FPM_USER}" "${PHP_FPM_GROUP}"
+set_gid "${PHP_FPM_GID}" "wp_php"
+set_uid "${PHP_FPM_UID}" "wp_php" "wp_php"
 
 # Execute CMD
 exec "$@"

--- a/php-fpm-php.conf
+++ b/php-fpm-php.conf
@@ -1,0 +1,3 @@
+[www]
+user  = wp_php
+group = wp_php

--- a/update.php
+++ b/update.php
@@ -285,6 +285,8 @@ foreach ( $php_versions as $version => $images ) {
 				}
 
 				$dockerfile = str_replace( '%%INSTALL_EXTENSIONS%%', $install_extensions, $dockerfile );
+
+				echo shell_exec( "cp -r docker-entrypoint.d $version/$image" );
 			}
 
 		} elseif ( $image === 'phpunit' ) {
@@ -313,6 +315,11 @@ foreach ( $php_versions as $version => $images ) {
 		// Copy the entrypoint script, if it exists.
 		if ( file_exists( "entrypoint-$image.sh" ) ) {
 			copy( "entrypoint-$image.sh", "$version/$image/entrypoint.sh" );
+		}
+
+		// Copy the PHP-FPM configuration, if it exists.
+		if ( file_exists( "php-fpm-$image.conf" ) ) {
+			copy( "php-fpm-$image.conf", "$version/$image/php-fpm.conf" );
 		}
 
 		// Generate the build and push commands for this image/version.


### PR DESCRIPTION
Closes #13.

This PR allows for the PHP-FPM process to have a dynamic UID/GID upon startup for the PHP container. This is accomplished by creating a user and group that matches the UID and GID of the host user.

By default, a user and group called `wp_php` is created with a UID/GID of 1000. PHP-FPM is then configured to run under this user and group. The UID and GID can be overriden upon startup of the container if needed by setting the `PHP_FPM_UID` and `PHP_FPM_GID` environment variables.