### PR TITLE
Update base image for PHP 7.4 to stable version

### DIFF
--- a/images/7.4/php/Dockerfile
+++ b/images/7.4/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-rc-fpm
+FROM php:7.4-fpm
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -162,7 +162,7 @@ $php_versions = array(
 	),
 	'7.4' => array(
 		'php' => array(
-			'base_name'       => 'php:7.4-rc-fpm',
+			'base_name'       => 'php:7.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring' ),
 			'pecl_extensions' => array( 'xdebug-2.8.0beta1', 'memcached-3.1.3', 'imagick' ),


### PR DESCRIPTION
This is still using RC which builds an image with 7.4.0RC6.