### PR TITLE
Multiple PHPUnit images marked as "latest"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ jobs:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/php:7.4-fpm$PR_TAG -t $PACKAGE_REGISTRY/php:latest$PR_TAG images/7.4/php
         - docker images
         - docker push $PACKAGE_REGISTRY/php:7.4-fpm$PR_TAG
-        - docker push $PACKAGE_REGISTRY/php:7.4-fpm$PR_TAG
+        - docker push $PACKAGE_REGISTRY/php:latest$PR_TAG
     - name: "php 8.0"
       script:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/php:8.0-fpm$PR_TAG images/8.0/php
@@ -232,7 +232,7 @@ jobs:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:7.4-fpm$PR_TAG -t $PACKAGE_REGISTRY/phpunit:latest$PR_TAG images/7.4/phpunit
         - docker images
         - docker push $PACKAGE_REGISTRY/phpunit:7.4-fpm$PR_TAG
-        - docker push $PACKAGE_REGISTRY/phpunit:7.4-fpm$PR_TAG
+        - docker push $PACKAGE_REGISTRY/phpunit:latest$PR_TAG
     - name: "phpunit 8 on php 7.4"
       script:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:8-php-7.4-fpm$PR_TAG images/phpunit/8-php-7.4
@@ -305,7 +305,7 @@ jobs:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/cli:7.4-fpm$PR_TAG -t $PACKAGE_REGISTRY/cli:latest$PR_TAG images/7.4/cli
         - docker images
         - docker push $PACKAGE_REGISTRY/cli:7.4-fpm$PR_TAG
-        - docker push $PACKAGE_REGISTRY/cli:7.4-fpm$PR_TAG
+        - docker push $PACKAGE_REGISTRY/cli:latest$PR_TAG
     - name: "cli 8.0"
       script:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/cli:8.0-fpm$PR_TAG images/8.0/cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,15 +235,13 @@ jobs:
         - docker push $PACKAGE_REGISTRY/phpunit:7.4-fpm$PR_TAG
     - name: "phpunit 8 on php 7.4"
       script:
-        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:8-php-7.4-fpm$PR_TAG -t $PACKAGE_REGISTRY/phpunit:latest$PR_TAG images/phpunit/8-php-7.4
+        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:8-php-7.4-fpm$PR_TAG images/phpunit/8-php-7.4
         - docker images
-        - docker push $PACKAGE_REGISTRY/phpunit:8-php-7.4-fpm$PR_TAG
         - docker push $PACKAGE_REGISTRY/phpunit:8-php-7.4-fpm$PR_TAG
     - name: "phpunit 7 on php 7.4"
       script:
-        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:7-php-7.4-fpm$PR_TAG -t $PACKAGE_REGISTRY/phpunit:latest$PR_TAG images/phpunit/7-php-7.4
+        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:7-php-7.4-fpm$PR_TAG images/phpunit/7-php-7.4
         - docker images
-        - docker push $PACKAGE_REGISTRY/phpunit:7-php-7.4-fpm$PR_TAG
         - docker push $PACKAGE_REGISTRY/phpunit:7-php-7.4-fpm$PR_TAG
     - name: "phpunit 8.0"
       script:

--- a/update.php
+++ b/update.php
@@ -480,7 +480,7 @@ function build_commands( $label, $image_type = 'php', $image_label = '7.3', $is_
 		"docker push \$PACKAGE_REGISTRY/{$image_type}:{$image_label}-fpm\$PR_TAG",
 	);
 	if ( $is_latest ) {
-		$commands[] = "docker push \$PACKAGE_REGISTRY/{$image_type}:{$image_label}-fpm\$PR_TAG";
+		$commands[] = "docker push \$PACKAGE_REGISTRY/{$image_type}:latest\$PR_TAG";
 	}
 
 	return $commands;

--- a/update.php
+++ b/update.php
@@ -394,8 +394,8 @@ foreach ( $php_versions as $version => $images ) {
 		echo "✅\n";
 	}
 
-	foreach ( $phpunit_versions as $phpunit_version => $php_versions ) {
-		if ( in_array( $version, $php_versions, true ) ) {
+	foreach ( $phpunit_versions as $phpunit_version => $supported_php_versions ) {
+		if ( in_array( $version, $supported_php_versions, true ) ) {
 			echo str_pad( "phpunit $phpunit_version", 15, '.' );
 
 			$php_version = $version;

--- a/update.php
+++ b/update.php
@@ -431,7 +431,7 @@ foreach ( $php_versions as $version => $images ) {
 				"phpunit {$phpunit_version} on php {$php_version}",
 				'phpunit',
 				"{$phpunit_version}-php-{$php_version}",
-				$version === $latest
+				false
 			);
 
 			echo "✅\n";


### PR DESCRIPTION
After #28, multiple PHPUnit images were being tagged as `latest`. This fixes that. Only the default PHPUnit image generated for the specified latest version of PHP should be marked as such.

Fixes #29.