### PR TITLE
Add PHPUnit 9 for PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -212,6 +212,11 @@ jobs:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:7.3-fpm$PR_TAG images/7.3/phpunit
         - docker images
         - docker push $PACKAGE_REGISTRY/phpunit:7.3-fpm$PR_TAG
+    - name: "phpunit 9 on php 7.3"
+      script:
+        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:9-php-7.3-fpm$PR_TAG images/phpunit/9-php-7.3
+        - docker images
+        - docker push $PACKAGE_REGISTRY/phpunit:9-php-7.3-fpm$PR_TAG
     - name: "phpunit 8 on php 7.3"
       script:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:8-php-7.3-fpm$PR_TAG images/phpunit/8-php-7.3
@@ -233,6 +238,11 @@ jobs:
         - docker images
         - docker push $PACKAGE_REGISTRY/phpunit:7.4-fpm$PR_TAG
         - docker push $PACKAGE_REGISTRY/phpunit:latest$PR_TAG
+    - name: "phpunit 9 on php 7.4"
+      script:
+        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:9-php-7.4-fpm$PR_TAG images/phpunit/9-php-7.4
+        - docker images
+        - docker push $PACKAGE_REGISTRY/phpunit:9-php-7.4-fpm$PR_TAG
     - name: "phpunit 8 on php 7.4"
       script:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:8-php-7.4-fpm$PR_TAG images/phpunit/8-php-7.4
@@ -248,6 +258,11 @@ jobs:
         - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:8.0-fpm$PR_TAG images/8.0/phpunit
         - docker images
         - docker push $PACKAGE_REGISTRY/phpunit:8.0-fpm$PR_TAG
+    - name: "phpunit 9 on php 8.0"
+      script:
+        - docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/phpunit:9-php-8.0-fpm$PR_TAG images/phpunit/9-php-8.0
+        - docker images
+        - docker push $PACKAGE_REGISTRY/phpunit:9-php-8.0-fpm$PR_TAG
 
     - stage: "Build CLI images"
       name: "cli 5.2"

--- a/images/8.0/phpunit/Dockerfile
+++ b/images/8.0/phpunit/Dockerfile
@@ -9,7 +9,7 @@ FROM $PACKAGE_REGISTRY/php:8.0-fpm$PR_TAG
 # You can find the relevant template in the `/templates` folder.
 #
 
-RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
+RUN curl -sL https://phar.phpunit.de/phpunit-9.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -182,7 +182,7 @@ $php_versions = array(
 			'pecl_extensions' => array(),
 			'composer'        => true,
 		),
-		'phpunit' => 7,
+		'phpunit' => 9,
 		'cli' => array(
 			'mysql_client' => 'virtual-mysql-client',
 			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
@@ -199,6 +199,11 @@ $php_versions = array(
  * @param array $phpunit_version A list of PHP versions for each PHPUnit version.
  */
 $phpunit_versions = array(
+	'9' => array(
+		'8.0',
+		'7.4',
+		'7.3',
+	),
 	'8' => array(
 		'7.4',
 		'7.3',


### PR DESCRIPTION
PHPUnit 9 is the first version of PHPUnit to support PHP8, the images need to be updated for that.

Related to https://core.trac.wordpress.org/ticket/46149

(Opening PR to test it, although, it should work as it's minimal and tested elsewhere)