### PR TITLE
PHP 8 Docker Updates

### DIFF
--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -25,11 +25,6 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	pecl install xdebug-2.8.0beta1; \
-	pecl install memcached-3.1.3; \
-	pecl install imagick; \
-	docker-php-ext-enable imagick; \
-	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \
 	php -r " \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM devilbox/php-fpm-8.0:latest
+FROM php-fpm-8.0:latest
 
 WORKDIR /var/www
 

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -28,6 +28,8 @@ RUN set -ex; \
 	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar; \
 	chmod +x /usr/local/bin/pickle; \
 	\
+	pickle install https://github.com/Imagick/imagick/archive/06116aa24b76edaf6b1693198f79e6c295eda8a9.tar.gz; \
+	docker-php-ext-enable imagick; \
 	pickle install memcached-3.1.5; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -17,9 +17,18 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	\
-	apt-get install -y --no-install-recommends unzip sudo rsync git; \
+	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libzip-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \
+	sed -i 's/^# *\(\(ru_RU\|fr_FR\|de_DE\|es_ES\|ja_JP\).UTF-8\)/\1/' /etc/locale.gen; \
+	locale-gen; \
 	\
-	docker-php-ext-install mysqli; \
+	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr; \
+	\
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	\
+	pecl install xdebug-2.8.0beta1; \
+	pecl install memcached-3.1.3; \
+	pecl install imagick; \
+	docker-php-ext-enable imagick; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -28,8 +28,6 @@ RUN set -ex; \
 	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar; \
 	chmod +x /usr/local/bin/pickle; \
 	\
-	pickle install https://github.com/Imagick/imagick/archive/06116aa24b76edaf6b1693198f79e6c295eda8a9.tar.gz; \
-	docker-php-ext-enable imagick; \
 	pickle install memcached-3.1.5; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -29,8 +29,6 @@ RUN set -ex; \
 	chmod +x /usr/local/bin/pickle; \
 	\
 	pickle install memcached-3.1.5; \
-	pickle install imagick; \
-	docker-php-ext-enable imagick; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -25,11 +25,11 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar \
-	chmod +x /usr/local/bin/pickle \
+	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar; \
+	chmod +x /usr/local/bin/pickle; \
 	\
-	pickle install memcached-3.1.5 --no-interaction; \
-	pickle install imagick --no-interaction; \
+	pickle install memcached-3.1.5; \
+	pickle install imagick; \
 	docker-php-ext-enable imagick; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.0beta4-fpm
+FROM php:8.0.0rc1-fpm
 
 WORKDIR /var/www
 

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php-fpm-8.0:latest
+FROM php:8.0.0beta4-fpm
 
 WORKDIR /var/www
 

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -25,6 +25,13 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
+	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar \
+	chmod +x /usr/local/bin/pickle \
+	\
+	pickle install memcached-3.1.5 --no-interaction; \
+	pickle install imagick --no-interaction; \
+	docker-php-ext-enable imagick; \
+	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \
 	php -r " \

--- a/update.php
+++ b/update.php
@@ -176,7 +176,7 @@ $php_versions = array(
 	),
 	'8.0' => array(
 		'php' => array(
-			'base_name'       => 'php-fpm-8.0:latest',
+			'base_name'       => 'php:8.0.0beta4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array(),

--- a/update.php
+++ b/update.php
@@ -179,7 +179,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.0.0beta4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array(),
+			'pecl_extensions' => array( 'memcached-3.1.5', 'imagick' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,
@@ -319,12 +319,22 @@ foreach ( $php_versions as $version => $images ) {
 
 				if ( $config['pecl_extensions'] ) {
 					$install_extensions .= " \\\n\t\\\n";
-					$install_extensions .= array_reduce( $config['pecl_extensions'], function ( $command, $extension ) {
+
+					if ( version_compare( $version, '8.0beta1' ) >= 0 ) {
+						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar \\\n";
+						$install_extensions .= "\tchmod +x /usr/local/bin/pickle \\\n\t\\\n";
+					}
+
+					$install_extensions .= array_reduce( $config['pecl_extensions'], function ( $command, $extension ) use ( $version ) {
 						if ( $command ) {
 							$command .= " \\\n";
 						}
 
-						$command .= "\tpecl install $extension;";
+						if ( version_compare( $version, '8.0beta1' ) >= 0 ) {
+							$command .= "\tpickle install $extension --no-interaction;";
+						} else {
+							$command .= "\tpecl install $extension;";
+						}
 
 						if ( 0 === strpos( $extension, 'imagick' ) ) {
 							$command .= " \\\n\tdocker-php-ext-enable imagick;";

--- a/update.php
+++ b/update.php
@@ -177,9 +177,9 @@ $php_versions = array(
 	'8.0' => array(
 		'php' => array(
 			'base_name'       => 'devilbox/php-fpm-8.0:latest',
-			'apt'             => array( 'unzip', 'sudo', 'rsync' ),
-			'extensions'      => array( 'mysqli' ),
-			'pecl_extensions' => array(),
+			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'pecl_extensions' => array( 'xdebug-2.8.0beta1', 'memcached-3.1.3', 'imagick' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,

--- a/update.php
+++ b/update.php
@@ -176,7 +176,7 @@ $php_versions = array(
 	),
 	'8.0' => array(
 		'php' => array(
-			'base_name'       => 'php:8.0.0beta4-fpm',
+			'base_name'       => 'php:8.0.0rc1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'memcached-3.1.5' ),

--- a/update.php
+++ b/update.php
@@ -179,7 +179,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.0.0beta4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'memcached-3.1.5', 'imagick' ),
+			'pecl_extensions' => array( 'memcached-3.1.5' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,

--- a/update.php
+++ b/update.php
@@ -320,7 +320,7 @@ foreach ( $php_versions as $version => $images ) {
 				if ( $config['pecl_extensions'] ) {
 					$install_extensions .= " \\\n\t\\\n";
 
-					if ( version_compare( $version, '8.0beta1' ) >= 0 ) {
+					if ( version_compare( $version, '7.4', '>' ) === true ) {
 						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar; \\\n";
 						$install_extensions .= "\tchmod +x /usr/local/bin/pickle; \\\n\t\\\n";
 					}
@@ -330,7 +330,7 @@ foreach ( $php_versions as $version => $images ) {
 							$command .= " \\\n";
 						}
 
-						if ( version_compare( $version, '8.0beta1' ) >= 0 ) {
+						if ( version_compare( $version, '7.4', '>' ) === true ) {
 							$command .= "\tpickle install $extension;";
 						} else {
 							$command .= "\tpecl install $extension;";

--- a/update.php
+++ b/update.php
@@ -179,7 +179,7 @@ $php_versions = array(
 			'base_name'       => 'devilbox/php-fpm-8.0:latest',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'xdebug-2.8.0beta1', 'memcached-3.1.3', 'imagick' ),
+			'pecl_extensions' => array(),
 			'composer'        => true,
 		),
 		'phpunit' => 9,

--- a/update.php
+++ b/update.php
@@ -179,7 +179,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.0.0rc1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick-06116aa24b76edaf6b1693198f79e6c295eda8a9', 'memcached-3.1.5' ),
+			'pecl_extensions' => array( 'memcached-3.1.5' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,
@@ -331,13 +331,7 @@ foreach ( $php_versions as $version => $images ) {
 						}
 
 						if ( version_compare( $version, '7.4', '>' ) === true ) {
-							// Imagick `master` branch currently has PHP 8.0 support.
-							if ( 0 === strpos( $extension, 'imagick' ) ) {
-								$imagick_version = substr( $extension, strpos( $extension, '-' )+ 1 );
-								$command .= "\tpickle install https://github.com/Imagick/imagick/archive/$imagick_version.tar.gz;";
-							} else {
-								$command .= "\tpickle install $extension;";
-							}
+							$command .= "\tpickle install $extension;";
 						} else {
 							$command .= "\tpecl install $extension;";
 						}

--- a/update.php
+++ b/update.php
@@ -176,7 +176,7 @@ $php_versions = array(
 	),
 	'8.0' => array(
 		'php' => array(
-			'base_name'       => 'devilbox/php-fpm-8.0:latest',
+			'base_name'       => 'php-fpm-8.0:latest',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array(),

--- a/update.php
+++ b/update.php
@@ -321,8 +321,8 @@ foreach ( $php_versions as $version => $images ) {
 					$install_extensions .= " \\\n\t\\\n";
 
 					if ( version_compare( $version, '8.0beta1' ) >= 0 ) {
-						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar \\\n";
-						$install_extensions .= "\tchmod +x /usr/local/bin/pickle \\\n\t\\\n";
+						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.6.0/pickle.phar; \\\n";
+						$install_extensions .= "\tchmod +x /usr/local/bin/pickle; \\\n\t\\\n";
 					}
 
 					$install_extensions .= array_reduce( $config['pecl_extensions'], function ( $command, $extension ) use ( $version ) {
@@ -331,7 +331,7 @@ foreach ( $php_versions as $version => $images ) {
 						}
 
 						if ( version_compare( $version, '8.0beta1' ) >= 0 ) {
-							$command .= "\tpickle install $extension --no-interaction;";
+							$command .= "\tpickle install $extension;";
 						} else {
 							$command .= "\tpecl install $extension;";
 						}

--- a/update.php
+++ b/update.php
@@ -179,7 +179,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.0.0rc1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'memcached-3.1.5' ),
+			'pecl_extensions' => array( 'imagick-06116aa24b76edaf6b1693198f79e6c295eda8a9', 'memcached-3.1.5' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,
@@ -331,7 +331,13 @@ foreach ( $php_versions as $version => $images ) {
 						}
 
 						if ( version_compare( $version, '7.4', '>' ) === true ) {
-							$command .= "\tpickle install $extension;";
+							// Imagick `master` branch currently has PHP 8.0 support.
+							if ( 0 === strpos( $extension, 'imagick' ) ) {
+								$imagick_version = substr( $extension, strpos( $extension, '-' )+ 1 );
+								$command .= "\tpickle install https://github.com/Imagick/imagick/archive/$imagick_version.tar.gz;";
+							} else {
+								$command .= "\tpickle install $extension;";
+							}
 						} else {
 							$command .= "\tpecl install $extension;";
 						}


### PR DESCRIPTION
This PR aims to bring the PHP8 Docker setup to match the ones for previous versions of PHP.

Changes:
- The `base_name` for PHP 8 was switched to `php:8.0:beta4-fpm`. Previously `devilbox` was used, but the PHP 8 image was using PHP 8.0.0-dev. Changing this to be more specific will require an update as newer 8.0 beta/RC releases are published, but it will be more accurate than `8.0.0-dev`.
- PEAR is now [disabled by default in PHP](https://github.com/php/php-src/pull/3781), and the ability to enable it may be removed in the future ([PHP externals discussion](https://externals.io/message/103977)). It seems this was done in PHP 7.4.x, but I'm not sure why that build is not failing as the PHP 8 one did when attempting to call `pecl install`. This PR installs [Pickle](https://github.com/FriendsOfPHP/pickle), which is new PHP extension installer [aiming to get Composer to fully support it](https://github.com/composer/composer/pull/2898#issuecomment-48439196).

Still missing, but not blockers (will require follow-up PRs when the libraries are updated):
- Imagick. The latest version (3.4.4) is not compatible with PHP 8.
- Xdebug. The [unreleased 3.0.0 version is required for PHP 8 support](https://xdebug.org/docs/compat).