### PR TITLE
Support extension installation even if Composer is not installed

### DIFF
--- a/update.php
+++ b/update.php
@@ -283,8 +283,10 @@ foreach ( $php_versions as $version => $images ) {
 			// Replace tags inside the PHP Dockerfile template.
 			$dockerfile = str_replace( '%%BASE_NAME%%', $config['base_name'], $dockerfile );
 
+			$install_extensions = '';
+
 			if ( $config['apt'] || $config['extensions'] || $config['pecl_extensions'] || $config['composer'] ) {
-				$install_extensions = "# install the PHP extensions we need\nRUN set -ex;";
+				$install_extensions .= "# install the PHP extensions we need\nRUN set -ex;";
 
 				// Composer requires git to be installed in some circumstances (e.g. `composer install --prefer-source`).
 				if ( $config['composer'] ) {
@@ -351,9 +353,9 @@ foreach ( $php_versions as $version => $images ) {
 					$install_extensions .= "\tcomposer --ansi --version --no-interaction; \\\n";
 					$install_extensions .= "\trm -f /tmp/installer.php /tmp/installer.sig;";
 				}
-
-				$dockerfile = str_replace( '%%INSTALL_EXTENSIONS%%', $install_extensions, $dockerfile );
 			}
+
+			$dockerfile = str_replace( '%%INSTALL_EXTENSIONS%%', $install_extensions, $dockerfile );
 
 			copy( "entrypoint/common.sh", "images/{$version}/{$image}/common.sh" );
 


### PR DESCRIPTION
The `str_replace()` call that replaces the `%%INSTALL_EXTENSIONS%%` token within the PHP Docker container template files is currently nested within the check for whether to install Composer. If a container configuration was ever added where Composer is not desired, the extension installation command would never make it into the Dockerfile.

The only container configured right now that this would affect is PHP 5.2, but because there are no extensions specified, no replacement will be attempted (the `%%INSTALL_EXTENSIONS%%` token is not present in the Dockerfile template anyways).

@pento Not sure if there was a specific reasoning for this or if this should stay how it is.