### PR TITLE
Change the default PHPUnit version on PHP 8 to version 7.x.

### DIFF
--- a/images/8.0/phpunit/Dockerfile
+++ b/images/8.0/phpunit/Dockerfile
@@ -9,7 +9,7 @@ FROM $PACKAGE_REGISTRY/php:8.0-fpm$PR_TAG
 # You can find the relevant template in the `/templates` folder.
 #
 
-RUN curl -sL https://phar.phpunit.de/phpunit-9.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
+RUN curl -sL https://phar.phpunit.de/phpunit-7.phar > /usr/local/bin/phpunit && chmod +x /usr/local/bin/phpunit
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -182,7 +182,7 @@ $php_versions = array(
 			'pecl_extensions' => array(),
 			'composer'        => true,
 		),
-		'phpunit' => 9,
+		'phpunit' => 7,
 		'cli' => array(
 			'mysql_client' => 'virtual-mysql-client',
 			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',


### PR DESCRIPTION
Because of the need to continue supporting PHP 5.6.20 in WordPress, the test suite has not been updated to be PHPUnit 9 compatible just yet. Instead, the necessary changes have been made to the local test suite in order to ensure PHP8 compatibility on PHPUnit 7.x.

The default PHPUnit version on the PHP 8 container needs to be changed to 7.x.

Note: I chose not to add PHP 8.0 to the PHPUnit 7 array because 7.x does not technically support PHP 8, even though WordPress' test suite does work like that. Don't feel strongly about this though. When the default version for PHP 8 is changed to PHPUnit 9, we could add that for those that don't wish to update their test runners just yet.

Relevant tickets and changesets:
- https://core.trac.wordpress.org/ticket/46149
- https://core.trac.wordpress.org/ticket/50913
- https://core.trac.wordpress.org/ticket/50902
- https://core.trac.wordpress.org/changeset/48957
- https://core.trac.wordpress.org/changeset/48972
- https://core.trac.wordpress.org/changeset/49037