### PR TITLE
PHP 8.0.0 GA

### DIFF
--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.0RC4-fpm
+FROM php:8.0-fpm
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -176,7 +176,7 @@ $php_versions = array(
 	),
 	'8.0' => array(
 		'php' => array(
-			'base_name'       => 'php:8.0.0RC4-fpm',
+			'base_name'       => 'php:8.0-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'memcached-3.1.5' ),


### PR DESCRIPTION
PHP 8.0 has officially been released.

Release notes: https://www.php.net/archive/2020.php#2020-11-26-3