### PR TITLE
Change the latest PHP to 8

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -47,7 +47,7 @@ jobs:
         php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
     env:
       PHP_VERSION: ${{ matrix.php }}
-      PHP_LATEST: '7.4'
+      PHP_LATEST: '8.2'
 
     steps:
       - name: Checkout repository
@@ -83,7 +83,7 @@ jobs:
 
     env:
       PHP_VERSION: ${{ matrix.php }}
-      PHP_LATEST: '7.4'
+      PHP_LATEST: '8.2'
 
     steps:
       - name: Checkout repository
@@ -146,7 +146,7 @@ jobs:
 
     env:
       PHP_VERSION: ${{ matrix.php }}
-      PHP_LATEST: '7.4'
+      PHP_LATEST: '8.2'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -56,7 +56,7 @@ jobs:
         php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
     env:
       PHP_VERSION: ${{ matrix.php }}
-      PHP_LATEST: '7.4'
+      PHP_LATEST: '8.2'
 
     steps:
       - name: Checkout repository
@@ -92,7 +92,7 @@ jobs:
 
     env:
       PHP_VERSION: ${{ matrix.php }}
-      PHP_LATEST: '7.4'
+      PHP_LATEST: '8.2'
 
     steps:
       - name: Checkout repository
@@ -155,7 +155,7 @@ jobs:
 
     env:
       PHP_VERSION: ${{ matrix.php }}
-      PHP_LATEST: '7.4'
+      PHP_LATEST: '8.2'
 
     steps:
       - name: Checkout repository

--- a/update.php
+++ b/update.php
@@ -1,7 +1,7 @@
 <?php
 
 // The latest stable version of PHP that is supported in WordPress trunk.
-$latest = '7.4';
+$latest = '8.2';
 
 /**
  * An array of all PHP versions that we need to generate images for, and their config settings.


### PR DESCRIPTION
This changes the version of PHP used in the `latest` tags to `8.2`.

I'm not sure we should merge this just yet though.

If we merge this, the latest PHPUnit image will become PHP 8 running PHPUnit 9.x, which is not supported by default by WordPress' test suite at the moment. Anyone relying on `latest` in their setups would potentially see their tests break.