### PR TITLE
Allow ImageMagick to work with PDFs

### DIFF
--- a/images/5.2/php/Dockerfile
+++ b/images/5.2/php/Dockerfile
@@ -26,6 +26,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/5.3/php/Dockerfile
+++ b/images/5.3/php/Dockerfile
@@ -47,6 +47,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/5.4/php/Dockerfile
+++ b/images/5.4/php/Dockerfile
@@ -50,6 +50,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/5.5/php/Dockerfile
+++ b/images/5.5/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/5.6.20/php/Dockerfile
+++ b/images/5.6.20/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/5.6/php/Dockerfile
+++ b/images/5.6/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/7.0/php/Dockerfile
+++ b/images/7.0/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/7.1/php/Dockerfile
+++ b/images/7.1/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/7.2/php/Dockerfile
+++ b/images/7.2/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/7.3/php/Dockerfile
+++ b/images/7.3/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/7.4/php/Dockerfile
+++ b/images/7.4/php/Dockerfile
@@ -49,6 +49,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -50,6 +50,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \

--- a/templates/Dockerfile-php.template
+++ b/templates/Dockerfile-php.template
@@ -13,6 +13,13 @@ COPY entrypoint.sh /entrypoint.sh
 COPY common.sh /common.sh
 COPY php-fpm.conf /usr/local/etc/php-fpm.d/zz-wordpress.conf
 
+ARG imagemagic_config=/etc/ImageMagick-6/policy.xml
+RUN if [ -f $imagemagic_config ] ; then \
+		sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="read|write" pattern="PDF" \/>/g' $imagemagic_config; \
+	else \
+		echo did not see file $imagemagic_config; \
+	fi
+
 RUN chmod +x /entrypoint.sh && \
     chmod +x /common.sh && \
     groupadd -g 1000 -r wp_php && \


### PR DESCRIPTION
The default ImageMagick config prevents working with PDFs, due to ongoing security issues in ghostscript.

For the purposes of development, these issues aren't a concern, so we can re-enable PDF support.