### PR TITLE
Bump PHP 8.1 to beta 2

### DIFF
--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0beta1-fpm
+FROM php:8.1.0beta2-fpm
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -190,7 +190,7 @@ $php_versions = array(
 	),
 	'8.1' => array(
 		'php' => array(
-			'base_name'       => 'php:8.1.0beta1-fpm',
+			'base_name'       => 'php:8.1.0beta2-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'memcached-3.1.5', 'xdebug-3.0.2' ),


### PR DESCRIPTION
PHP 8.1 beta 2 was released last week: https://www.php.net/archive/2021.php#2021-08-05-2