### PR TITLE
Bump PHP 8.1 to RC(1)

### DIFF
--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1.0beta2-fpm
+FROM php:8.1-rc-fpm
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -190,7 +190,7 @@ $php_versions = array(
 	),
 	'8.1' => array(
 		'php' => array(
-			'base_name'       => 'php:8.1.0beta2-fpm',
+			'base_name'       => 'php:8.1-rc-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'memcached-3.1.5', 'xdebug-3.0.4' ),


### PR DESCRIPTION
PHP 8.1-RC1 was released last week: https://www.php.net/archive/2021.php#2021-09-02-1

To not have to update the image tags every two weeks for the next few months, I propose to use the `8.1-rc-fpm` image which should automatically update to the latest RC once released.

Refs:
* https://github.com/docker-library/docs/tree/master/php