### PR TITLE
Correct path filtering in GitHub Action workflow

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -16,6 +16,7 @@ on:
       - 'entrypoint/**'
       - 'images/**'
       - '.github/workflows/docker-hub.yml'
+  workflow_dispatch:
   # Once weekly On Sundays at 00:00 UTC.
   schedule:
     - cron: '0 0 * * 0'

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -12,9 +12,9 @@ on:
     branches:
       - master
     paths:
-      - 'config'
-      - 'entrypoint'
-      - 'images'
+      - 'config/**'
+      - 'entrypoint/**'
+      - 'images/**'
       - '.github/workflows/docker-hub.yml'
   # Once weekly On Sundays at 00:00 UTC.
   schedule:

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -7,10 +7,11 @@ on:
     branches:
       - master
     paths:
-      - 'config'
-      - 'entrypoint'
-      - 'images'
+      - 'config/**'
+      - 'entrypoint/**'
+      - 'images/**'
       - '.github/workflows/docker-hub.yml'
+  workflow_dispatch:
   # Once weekly On Sundays at 00:00 UTC.
   schedule:
     - cron: '0 0 * * 0'


### PR DESCRIPTION
This corrects the file paths used for events to trigger building and pushing containers to Docker.

It also adds the `workflow_dispatch` event to allow the containers to be manually rebuilt and pushed should there be an issue.