### PR TITLE
Update pickle and xDebug

### DIFF
--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -27,11 +27,11 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.4/pickle.phar; \
+	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.7/pickle.phar; \
 	chmod +x /usr/local/bin/pickle; \
 	\
 	pickle install memcached-3.1.5; \
-	pickle install xdebug-3.0.4; \
+	pickle install xdebug-3.1.1; \
 	pickle install imagick; \
 	docker-php-ext-enable imagick; \
 	\

--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -27,11 +27,11 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.4/pickle.phar; \
+	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.7/pickle.phar; \
 	chmod +x /usr/local/bin/pickle; \
 	\
 	pickle install memcached-3.1.5; \
-	pickle install xdebug-3.0.4; \
+	pickle install xdebug-3.1.1; \
 	pickle install imagick; \
 	docker-php-ext-enable imagick; \
 	\

--- a/update.php
+++ b/update.php
@@ -179,7 +179,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.0-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'memcached-3.1.5', 'xdebug-3.0.4', 'imagick' ),
+			'pecl_extensions' => array( 'memcached-3.1.5', 'xdebug-3.1.1', 'imagick' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,
@@ -193,7 +193,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.1-rc-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'memcached-3.1.5', 'xdebug-3.0.4', 'imagick' ),
+			'pecl_extensions' => array( 'memcached-3.1.5', 'xdebug-3.1.1', 'imagick' ),
 			'composer'        => true,
 		),
 		'phpunit' => 9,
@@ -338,7 +338,7 @@ foreach ( $php_versions as $version => $images ) {
 					$install_extensions .= " \\\n\t\\\n";
 
 					if ( version_compare( $version, '7.4', '>' ) === true ) {
-						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.4/pickle.phar; \\\n";
+						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.7/pickle.phar; \\\n";
 						$install_extensions .= "\tchmod +x /usr/local/bin/pickle; \\\n\t\\\n";
 					}
 


### PR DESCRIPTION
This updates pickle from v0.7.4 to v0.7.7 and xDebug from 3.0.4 to 3.1.1. These updates only affect the PHP 8.0 and 8.1 containers.