### PR TITLE
GH Actions: allow for manually triggering a workflow

### DIFF
--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -10,6 +10,7 @@ name: Build test images
 
 on:
   pull_request:
+  workflow_dispatch:
 
 env:
   REGISTRY_USERNAME: desrosj

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -28,6 +28,7 @@ name: Build test images
 
 on:
   pull_request:
+  workflow_dispatch:
 
 env:
   REGISTRY_USERNAME: desrosj


### PR DESCRIPTION
Triggering a workflow for a branch manually is not supported by default in GH Actions, but has to be explicitly allowed.

This is useful if, for instance, an external action script or a dependency has broken.
Once a fix is available, failing builds for open PRs can be retriggered manually instead of having to be re-pushed to retrigger the workflow.

Note:
* The `docker-hub` workflow already contained the trigger, but the `github-container-registry` workflow did not.

I noticed it was missing when I wanted to manual trigger a re-build of the `master` branch to verify that the build failures I'm seeing for PR #80 and #81 are unrelated to this PRs.

Ref: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/