### PR TITLE
Fix build issues with PHP 5.3 image

### DIFF
--- a/images/5.3/php/Dockerfile
+++ b/images/5.3/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM devilbox/php-fpm-5.3:latest
+FROM devilbox/php-fpm-5.3:0.24
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -36,7 +36,7 @@ $php_versions = array(
 	),
 	'5.3' => array(
 		'php' => array(
-			'base_name'       => 'devilbox/php-fpm-5.3:latest',
+			'base_name'       => 'devilbox/php-fpm-5.3:0.24',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libicu-dev', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'zendopcache-7.0.5', 'xdebug-2.2.7' ),


### PR DESCRIPTION
This changes the base image of the 5.3 PHP container to `devilbox/php-fpm-5.3:0.24`.

It seems that some upstream changes to devilbox has caused the building of the PHP container to fail. Version 0.24 was the last version to succeed. Since this is a really old version of PHP and we're not concerned with receiving updates, a specific tag can be used.