### PR TITLE
Change the primary branch from `master` to `trunk`.

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -10,7 +10,7 @@ name: Build and publish images to Docker Hub
 on:
   push:
     branches:
-      - master
+      - trunk
     paths:
       - 'config/**'
       - 'entrypoint/**'

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -5,7 +5,7 @@ name: Build and publish images to Docker Hub
 on:
   push:
     branches:
-      - master
+      - trunk
     paths:
       - 'config/**'
       - 'entrypoint/**'


### PR DESCRIPTION
This makes the repository consistent with others under the WordPress organization.

For more context, see https://make.wordpress.org/core/2020/06/18/proposal-update-all-git-repositories-to-use-main-instead-of-master/#comment-39524.