### PR TITLE
Fix memory problem in PHP 5.3 CLI container

### DIFF
--- a/images/5.3/php/Dockerfile
+++ b/images/5.3/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM devilbox/php-fpm-5.3:0.24
+FROM devilbox/php-fpm-5.3:0.21
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -36,7 +36,7 @@ $php_versions = array(
 	),
 	'5.3' => array(
 		'php' => array(
-			'base_name'       => 'devilbox/php-fpm-5.3:0.24',
+			'base_name'       => 'devilbox/php-fpm-5.3:0.21',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libicu-dev', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'zendopcache-7.0.5', 'xdebug-2.2.7' ),


### PR DESCRIPTION
This is a follow up to #84 to pin an even earlier version of devilbox for PHP 5.3, which was the version used in the last successful build. #84 is resulting in some memory related issues in the CLI container, which is preventing WordPress from installing before running unit tests.