### PR TITLE
Add a Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Configure Dependabot scanning.
+version: 2
+
+updates:
+  # Check for updates to GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This adds a Dependabot configuration file to check weekly for updates to GitHub Actions, which helps keep these up to date.