### PR TITLE
Ensure that Debian stretch is found

### DIFF
--- a/images/7.0/php/Dockerfile
+++ b/images/7.0/php/Dockerfile
@@ -15,6 +15,8 @@ ENV COMPOSER_HOME /tmp
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	echo 'deb http://archive.debian.org/debian stretch main contrib non-free' | tee /etc/apt/sources.list; \
+	\
 	apt-get update; \
 	\
 	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \

--- a/update.php
+++ b/update.php
@@ -355,6 +355,11 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 
 				if ( $config['apt'] ) {
 					$install_extensions .= " \\\n\t\\\n\t";
+					// Debian 9/stretch was moved to archive.debian.org in March 2023. See https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html.
+					if ( $version == '7.0' ) {
+						$install_extensions .= "echo 'deb http://archive.debian.org/debian stretch main contrib non-free' | tee /etc/apt/sources.list; \\\n\t\\\n\t";
+					}
+
 					$install_extensions .= "apt-get update; \\\n\t\\\n\tapt-get install -y --no-install-recommends " . implode( ' ', $config['apt'] ) . ";";
 
 					// Ensure certificates are updated.


### PR DESCRIPTION
There are some new failures that popped up when trying to build PHP 7.0 containers.

<details>
<summary markdown="span">Error log output</summary>

```
Err:7 http://security.debian.org/debian-security stretch/updates/main amd64 Packages
  404  Not Found [IP: 151.101.2.132 80]
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Ign:9 http://deb.debian.org/debian stretch/main amd64 Packages
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Ign:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Err:9 http://deb.debian.org/debian stretch/main amd64 Packages
  404  Not Found
Ign:10 http://deb.debian.org/debian stretch/main all Packages
Err:11 http://deb.debian.org/debian stretch-updates/main amd64 Packages
  404  Not Found
Ign:12 http://deb.debian.org/debian stretch-updates/main all Packages
Reading package lists...
W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.2.132 80]
E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
```

</details>

It looks like [Debian 9/stretch](https://lists.debian.org/debian-devel-announce/2023/03/msg00006.html) has been moved to a new URL and not configured a way for this to be seamless. This PR adjusts the `sources.list` to point to the new location.