### PR TITLE
Fix issues with building containers related to libmemcached-dev.

### DIFF
--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm
+FROM php:8.1-fpm-bullseye
 
 WORKDIR /var/www
 

--- a/images/8.2/php/Dockerfile
+++ b/images/8.2/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm
+FROM php:8.2-fpm-bullseye
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -343,7 +343,10 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 
 		if ( $image === 'php' ) {
             // Temporarily enforce using an image that is correctly installing `libmemcached-dev`.
-            $current_base_name = str_replace( 'php:8.2-fpm', 'php:8.2-fpm-bullseye', $config['base_name'] );
+			$current_base_name = $config['base_name'];
+			if ( in_array( $config['base_name'], array( 'php:8.1-fpm', 'php:8.2-fpm' ) ) ) {
+            	$current_base_name = str_replace( '-fpm', '-fpm-bullseye',  );
+			}
 
             // Replace tags inside the PHP Dockerfile template.
 			$dockerfile = str_replace( '%%BASE_NAME%%', $current_base_name, $dockerfile );

--- a/update.php
+++ b/update.php
@@ -342,8 +342,11 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 		$dockerfile = str_replace( '%%VERSION_TAG%%', $version_tag, $dockerfile );
 
 		if ( $image === 'php' ) {
-			// Replace tags inside the PHP Dockerfile template.
-			$dockerfile = str_replace( '%%BASE_NAME%%', $config['base_name'], $dockerfile );
+            // Temporarily enforce using an image that is correctly installing `libmemcached-dev`.
+            $current_base_name = str_replace( 'php:8.2-fpm', 'php:8.2-fpm-bullseye', $config['base_name'] );
+
+            // Replace tags inside the PHP Dockerfile template.
+			$dockerfile = str_replace( '%%BASE_NAME%%', $current_base_name, $dockerfile );
 
 			if ( $config['apt'] || $config['extensions'] || $config['pecl_extensions'] || $config['composer'] ) {
 				$install_extensions = "# install the PHP extensions we need\nRUN set -ex;";

--- a/update.php
+++ b/update.php
@@ -345,7 +345,7 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
             // Temporarily enforce using an image that is correctly installing `libmemcached-dev`.
 			$current_base_name = $config['base_name'];
 			if ( in_array( $config['base_name'], array( 'php:8.1-fpm', 'php:8.2-fpm' ) ) ) {
-            	$current_base_name = str_replace( '-fpm', '-fpm-bullseye',  );
+            	$current_base_name = str_replace( '-fpm', '-fpm-bullseye', $current_base_name );
 			}
 
             // Replace tags inside the PHP Dockerfile template.


### PR DESCRIPTION
It seems that recently, the PHP 8.2 and 8.1 images were changed from Debian 11 "bullseye" to Debian 12 "bookworm". The latter seems to have issues where `libmemcached-dev` is not being installed correctly.

This PR temporarily enforces using bullseye to build the PHP 8.2 and 8.1 containers until that issue can be resolved.

See https://serverfault.com/a/1134020.