### PR TITLE
Deprecate 7.0 and 7.1 containers.

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -44,7 +44,7 @@ jobs:
     
     strategy:
       matrix:
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.2'
@@ -79,7 +79,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -114,7 +114,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        phpunit: [ '7-php-7.0', '6-php-7.0', '5-php-7.0', '7-php-7.1', '6-php-7.1', '8-php-7.2', '7-php-7.2', '6-php-7.2', '9-php-7.3', '8-php-7.3', '7-php-7.3', '6-php-7.3', '9-php-7.4', '8-php-7.4', '7-php-7.4', '9-php-8.0', '8-php-8.0', '9-php-8.1', '8-php-8.1', '9-php-8.2', '8-php-8.2', '9-php-8.3' ]
+        phpunit: [ '8-php-7.2', '7-php-7.2', '6-php-7.2', '9-php-7.3', '8-php-7.3', '7-php-7.3', '6-php-7.3', '9-php-7.4', '8-php-7.4', '7-php-7.4', '9-php-8.0', '8-php-8.0', '9-php-8.1', '8-php-8.1', '9-php-8.2', '8-php-8.2', '9-php-8.3' ]
 
     env:
       PHPUNIT_VERSION: ${{ matrix.phpunit }}
@@ -142,7 +142,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     env:
       PHP_VERSION: ${{ matrix.php }}

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [ check-for-changes ]
     strategy:
       matrix:
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.2'
@@ -88,7 +88,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -123,7 +123,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        phpunit: [ '7-php-7.0', '6-php-7.0', '5-php-7.0', '7-php-7.1', '6-php-7.1', '8-php-7.2', '7-php-7.2', '6-php-7.2', '9-php-7.3', '8-php-7.3', '7-php-7.3', '6-php-7.3', '9-php-7.4', '8-php-7.4', '7-php-7.4', '9-php-8.0', '8-php-8.0', '9-php-8.1', '8-php-8.1', '9-php-8.2', '8-php-8.2', '9-php-8.3' ]
+        phpunit: [ '8-php-7.2', '7-php-7.2', '6-php-7.2', '9-php-7.3', '8-php-7.3', '7-php-7.3', '6-php-7.3', '9-php-7.4', '8-php-7.4', '7-php-7.4', '9-php-8.0', '8-php-8.0', '9-php-8.1', '8-php-8.1', '9-php-8.2', '8-php-8.2', '9-php-8.3' ]
 
     env:
       PHPUNIT_VERSION: ${{ matrix.phpunit }}
@@ -151,7 +151,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        php: [ '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     env:
       PHP_VERSION: ${{ matrix.php }}

--- a/update.php
+++ b/update.php
@@ -8,7 +8,7 @@ $latest = '8.2';
  *
  * Each PHP version has settings for the PHP base image, the PHPUnit image, and the WP_CLI image.
  *
- * The minimum version of PHP required as of WordPress 5.2 is 5.6.20+.
+ * The minimum version of PHP required as of WordPress 6.6 is 7.2.24+.
  *
  * @see https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
  *
@@ -27,34 +27,6 @@ $latest = '8.2';
  * }
  */
 $php_versions = array(
-	'7.0' => array(
-		'php' => array(
-			'base_name'       => 'php:7.0-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'xdebug-2.7.2', 'memcached-3.1.5', 'imagick' ),
-			'composer'        => true,
-		),
-		'phpunit' => 6,
-		'cli' => array(
-			'mysql_client' => 'virtual-mysql-client',
-			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
-		),
-	),
-	'7.1' => array(
-		'php' => array(
-			'base_name'       => 'php:7.1-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'xdebug-2.9.8', 'memcached-3.1.5', 'imagick' ),
-			'composer'        => true,
-		),
-		'phpunit' => 7,
-		'cli' => array(
-			'mysql_client' => 'virtual-mysql-client',
-			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
-		),
-	),
 	'7.2' => array(
 		'php' => array(
 			'base_name'       => 'php:7.2-fpm',
@@ -176,9 +148,6 @@ $php_versions = array(
  *
  * These versions of PHP have been unsupported for some time, and rarely need to be regenerated.
  *
- * Note: PHP 5.6 is still supported by WordPress, but suffers from the same problems as earlier versions.
- * 5.6 is also still supported, but does not need to be regenerated.
- *
  * @see https://make.wordpress.org/core/handbook/references/php-compatibility-and-wordpress-versions/
  *
  * @param array $php {
@@ -272,6 +241,34 @@ $legacy_php_versions = array(
 			'composer'        => true,
 		),
 		'phpunit' => 5,
+		'cli' => array(
+			'mysql_client' => 'virtual-mysql-client',
+			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+		),
+	),
+	'7.0' => array(
+		'php' => array(
+			'base_name'       => 'php:7.0-fpm',
+			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'pecl_extensions' => array( 'xdebug-2.7.2', 'memcached-3.1.5', 'imagick' ),
+			'composer'        => true,
+		),
+		'phpunit' => 6,
+		'cli' => array(
+			'mysql_client' => 'virtual-mysql-client',
+			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+		),
+	),
+	'7.1' => array(
+		'php' => array(
+			'base_name'       => 'php:7.1-fpm',
+			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'pecl_extensions' => array( 'xdebug-2.9.8', 'memcached-3.1.5', 'imagick' ),
+			'composer'        => true,
+		),
+		'phpunit' => 7,
 		'cli' => array(
 			'mysql_client' => 'virtual-mysql-client',
 			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',


### PR DESCRIPTION
This moves the PHP 7.0 & 7.1 containers to `$legacy_php_versions` so that the containers are no longer built with every change.

These containers rarely change and only exist to allow the tests for older branches of WordPress to run using Docker containers. They are also largely abandoned upstream and have not been updated in over 5 years.

Previously #93.