### PR TITLE
Update the PHP 8.4 container to 8.4 standard

### DIFF
--- a/images/8.4/php/Dockerfile
+++ b/images/8.4/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-rc-fpm
+FROM php:8.4-fpm
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -127,7 +127,7 @@ $php_versions = array(
 	),
 	'8.4' => array(
 		'php' => array(
-			'base_name'       => 'php:8.4-rc-fpm',
+			'base_name'       => 'php:8.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array(),


### PR DESCRIPTION
PHP 8.4 was [officially released today](https://www.php.net/archive/2024.php#2024-11-21-4). This updates the 8.4 image to use the non-RC containers.