### PR TITLE
Switch back to using PECL for PHP 8.x and remove Pickle.

### DIFF
--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -27,12 +27,9 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
-	chmod +x /usr/local/bin/pickle; \
-	\
-	pickle install memcached-3.2.0; \
-	pickle install xdebug-3.4.0; \
-	pickle install imagick; \
+	pecl install memcached-3.2.0; \
+	pecl install xdebug-3.4.0; \
+	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \

--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -27,12 +27,9 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
-	chmod +x /usr/local/bin/pickle; \
-	\
-	pickle install memcached-3.2.0; \
-	pickle install xdebug-3.4.0; \
-	pickle install imagick; \
+	pecl install memcached-3.2.0; \
+	pecl install xdebug-3.4.0; \
+	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \

--- a/images/8.2/php/Dockerfile
+++ b/images/8.2/php/Dockerfile
@@ -27,12 +27,9 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
-	chmod +x /usr/local/bin/pickle; \
-	\
-	pickle install memcached-3.2.0; \
-	pickle install xdebug-3.4.0; \
-	pickle install imagick; \
+	pecl install memcached-3.2.0; \
+	pecl install xdebug-3.4.0; \
+	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \

--- a/images/8.3/php/Dockerfile
+++ b/images/8.3/php/Dockerfile
@@ -27,10 +27,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
-	chmod +x /usr/local/bin/pickle; \
-	\
-	pickle install xdebug-3.4.0; \
+	pecl install xdebug-3.4.0; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.4/php/Dockerfile
+++ b/images/8.4/php/Dockerfile
@@ -27,10 +27,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
 	\
-	curl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \
-	chmod +x /usr/local/bin/pickle; \
-	\
-	pickle install xdebug-3.4.0; \
+	pecl install xdebug-3.4.0; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/update.php
+++ b/update.php
@@ -423,21 +423,12 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 				if ( $config['pecl_extensions'] ) {
 					$install_extensions .= " \\\n\t\\\n";
 
-					if ( version_compare( $version, '7.4', '>' ) === true ) {
-						$install_extensions .= "\tcurl --location --output /usr/local/bin/pickle https://github.com/FriendsOfPHP/pickle/releases/download/v0.7.11/pickle.phar; \\\n";
-						$install_extensions .= "\tchmod +x /usr/local/bin/pickle; \\\n\t\\\n";
-					}
-
 					$install_extensions .= array_reduce( $config['pecl_extensions'], function ( $command, $extension ) use ( $version ) {
 						if ( $command ) {
 							$command .= " \\\n";
 						}
 
-						if ( version_compare( $version, '7.4', '>' ) === true ) {
-							$command .= "\tpickle install $extension;";
-						} else {
-							$command .= "\tpecl install $extension;";
-						}
+						$command .= "\tpecl install $extension;";
 
 						if ( 0 === strpos( $extension, 'imagick' ) ) {
 							$command .= " \\\n\tdocker-php-ext-enable imagick;";


### PR DESCRIPTION
Previously, the Dockerfiles in this repo were updated to use Pickle to install packages on PHP 8.0+ because PECL packages would fail to install and cause build errors.

It seems that this was due to some confusion around changes in PHP related to PEAR/PECL. It was not removed, but was instead disabled by default and Docker containers were not adding the now required `--with-pear`.

This PR shows demonstrates that that has been resolved and Pickle can be removed in favor of `pecl` again. Pickle was always buggy and prevented the installation of beta/RC versions anyway. See also https://github.com/docker-library/php/pull/1088.