### PR TITLE
Set the WP-CLI cache directory to something we know is writable

### DIFF
--- a/images/5.3/cli/Dockerfile
+++ b/images/5.3/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/5.4/cli/Dockerfile
+++ b/images/5.4/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/5.5/cli/Dockerfile
+++ b/images/5.5/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/5.6.20/cli/Dockerfile
+++ b/images/5.6.20/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/5.6/cli/Dockerfile
+++ b/images/5.6/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/7.0/cli/Dockerfile
+++ b/images/7.0/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/7.1/cli/Dockerfile
+++ b/images/7.1/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/7.2/cli/Dockerfile
+++ b/images/7.2/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/7.3/cli/Dockerfile
+++ b/images/7.3/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/7.4/cli/Dockerfile
+++ b/images/7.4/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/8.0/cli/Dockerfile
+++ b/images/8.0/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/8.1/cli/Dockerfile
+++ b/images/8.1/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/8.2/cli/Dockerfile
+++ b/images/8.2/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/8.3/cli/Dockerfile
+++ b/images/8.3/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/images/8.4/cli/Dockerfile
+++ b/images/8.4/cli/Dockerfile
@@ -32,6 +32,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 

--- a/templates/Dockerfile-cli.template
+++ b/templates/Dockerfile-cli.template
@@ -27,6 +27,9 @@ COPY entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
+# WP CLI config
+ENV WP_CLI_CACHE_DIR=/tmp/wp-cli
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 %%/NEW_PHP%%
 


### PR DESCRIPTION
The default cache directory is `~/.wp-cli/cache` which means `/root/.wp-cli/cache` in this container, which isn't writable. This changes it to a path within the temp directory.

Props go to @mikelittle who fixed this in the Altis Local Server container configuration. I'm just copying his solution!

Fixes #122 