### PR TITLE
Adding FTP for testing purposes

### DIFF
--- a/images/5.3/php/Dockerfile
+++ b/images/5.3/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install zendopcache-7.0.5; \
 	pecl install xdebug-2.2.7; \

--- a/images/5.4/php/Dockerfile
+++ b/images/5.4/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install zendopcache-7.0.5; \
 	pecl install xdebug-2.4.1; \

--- a/images/5.5/php/Dockerfile
+++ b/images/5.5/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-2.5.5; \
 	pecl install memcached-2.2.0; \

--- a/images/5.6.20/php/Dockerfile
+++ b/images/5.6.20/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-2.5.5; \
 	pecl install memcached-2.2.0; \

--- a/images/5.6/php/Dockerfile
+++ b/images/5.6/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd mysql mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-2.5.5; \
 	pecl install memcached-2.2.0; \

--- a/images/7.0/php/Dockerfile
+++ b/images/7.0/php/Dockerfile
@@ -27,7 +27,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-2.7.2; \
 	pecl install memcached-3.1.5; \

--- a/images/7.1/php/Dockerfile
+++ b/images/7.1/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-2.9.8; \
 	pecl install memcached-3.1.5; \

--- a/images/7.2/php/Dockerfile
+++ b/images/7.2/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-3.1.6; \
 	pecl install memcached-3.3.0; \

--- a/images/7.3/php/Dockerfile
+++ b/images/7.3/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-3.1.6; \
 	pecl install memcached-3.3.0; \

--- a/images/7.4/php/Dockerfile
+++ b/images/7.4/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-3.1.6; \
 	pecl install memcached-3.3.0; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.2/php/Dockerfile
+++ b/images/8.2/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.3/php/Dockerfile
+++ b/images/8.3/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.4/php/Dockerfile
+++ b/images/8.4/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/update.php
+++ b/update.php
@@ -31,7 +31,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.2-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-3.1.6', 'memcached-3.3.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -45,7 +45,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.3-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-3.1.6', 'memcached-3.3.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -59,7 +59,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-3.1.6', 'memcached-3.3.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -73,7 +73,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.0-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -87,7 +87,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -101,7 +101,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.2-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -115,7 +115,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.3-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0' ),
 			'composer'        => true,
 		),
@@ -129,7 +129,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0' ),
 			'composer'        => true,
 		),
@@ -180,7 +180,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'devilbox/php-fpm-5.3:0.21',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libicu-dev', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'zendopcache-7.0.5', 'xdebug-2.2.7' ),
 			'composer'        => true,
 		),
@@ -194,7 +194,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:5.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libicu-dev', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'zendopcache-7.0.5', 'xdebug-2.4.1', 'memcached-2.2.0', 'imagick-3.4.4' ),
 			'composer'        => true,
 		),
@@ -208,7 +208,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:5.5-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libicu-dev', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-2.5.5', 'memcached-2.2.0', 'imagick-3.4.4' ),
 			'composer'        => true,
 		),
@@ -222,7 +222,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:5.6.20-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libicu-dev', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-2.5.5', 'memcached-2.2.0', 'imagick-3.4.4' ),
 			'composer'        => true,
 		),
@@ -236,7 +236,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:5.6-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'mysql', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-2.5.5', 'memcached-2.2.0', 'imagick-3.4.4' ),
 			'composer'        => true,
 		),
@@ -250,7 +250,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.0-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-2.7.2', 'memcached-3.1.5', 'imagick' ),
 			'composer'        => true,
 		),
@@ -264,7 +264,7 @@ $legacy_php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-2.9.8', 'memcached-3.1.5', 'imagick' ),
 			'composer'        => true,
 		),


### PR DESCRIPTION
Referencing this issue: https://github.com/WordPress/wpdev-docker-images/issues/164
And this core patch: https://github.com/WordPress/wordpress-develop/pull/8589
The idea is to provide FTP testing features to the image to test and debug FTP-related topics.