### PR TITLE
Add support for FTP extension.

### DIFF
--- a/images/7.2/php/Dockerfile
+++ b/images/7.2/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-3.1.6; \
 	pecl install memcached-3.3.0; \

--- a/images/7.3/php/Dockerfile
+++ b/images/7.3/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-3.1.6; \
 	pecl install memcached-3.3.0; \

--- a/images/7.4/php/Dockerfile
+++ b/images/7.4/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install xdebug-3.1.6; \
 	pecl install memcached-3.3.0; \

--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.2/php/Dockerfile
+++ b/images/8.2/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.3/php/Dockerfile
+++ b/images/8.3/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.4/php/Dockerfile
+++ b/images/8.4/php/Dockerfile
@@ -25,7 +25,7 @@ RUN set -ex; \
 	\
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
-	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl ftp; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/update.php
+++ b/update.php
@@ -31,7 +31,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.2-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-3.1.6', 'memcached-3.3.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -45,7 +45,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.3-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-3.1.6', 'memcached-3.3.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -59,7 +59,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:7.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'xdebug-3.1.6', 'memcached-3.3.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -73,7 +73,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.0-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -87,7 +87,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -101,7 +101,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.2-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
 		),
@@ -115,7 +115,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.3-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0' ),
 			'composer'        => true,
 		),
@@ -129,7 +129,7 @@ $php_versions = array(
 		'php' => array(
 			'base_name'       => 'php:8.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl', 'ftp' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0' ),
 			'composer'        => true,
 		),


### PR DESCRIPTION
From #165:

> Referencing this issue: https://github.com/WordPress/wpdev-docker-images/issues/164
> And this core patch: https://github.com/WordPress/wordpress-develop/pull/8589
> The idea is to provide FTP testing features to the image to test and debug FTP-related topics.

The GHA workflows do not currently support pull requests that originate from a fork.

cc @SirLouen