### PR TITLE
GitHub Actions workflow file security hardening

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -68,10 +68,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
-          --build-arg PR_TAG="$PR_TAG" \
-          -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
-          "images/$PHP_VERSION/php"
+            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+            --build-arg PR_TAG="$PR_TAG" \
+            -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
+            "images/$PHP_VERSION/php"
 
       - name: Log Docker images
         run: docker images
@@ -113,10 +113,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
-          --build-arg PR_TAG="$PR_TAG" \
-          -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
-          "images/$PHP_VERSION/cli"
+            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+            --build-arg PR_TAG="$PR_TAG" \
+            -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
+            "images/$PHP_VERSION/cli"
 
       - name: Log Docker images
         run: docker images

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -63,23 +63,28 @@ jobs:
 
       - name: Login to the package registry
         run: |
-          echo "$REGISTRY_PASSWORD" | docker login $PACKAGE_REGISTRY_HOST -u "$REGISTRY_USERNAME" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build Docker image
-        run: docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG images/$PHP_VERSION/php
+        run: |
+          docker build \
+          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+          --build-arg PR_TAG="$PR_TAG" \
+          -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
+          "images/$PHP_VERSION/php"
 
       - name: Log Docker images
         run: docker images
 
       - name: Push Docker image
-        run: docker push $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG
+        run: docker push "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG"
 
       - name: Push image as latest
         if: ${{ env.PHP_LATEST == env.PHP_VERSION }}
         run: |
-          docker image tag $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG $PACKAGE_REGISTRY/php:latest$PR_TAG
+          docker image tag "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" "$PACKAGE_REGISTRY/php:latest$PR_TAG"
           docker images
-          docker push $PACKAGE_REGISTRY/php:latest$PR_TAG
+          docker push "$PACKAGE_REGISTRY/php:latest$PR_TAG"
 
   build-cli-images:
     name: CLI on PHP ${{ matrix.php }}
@@ -103,19 +108,24 @@ jobs:
 
       - name: Login to the package registry
         run: |
-          echo "$REGISTRY_PASSWORD" | docker login $PACKAGE_REGISTRY_HOST -u "$REGISTRY_USERNAME" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build Docker image
-        run: docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG images/$PHP_VERSION/cli
+        run: |
+          docker build \
+          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+          --build-arg PR_TAG="$PR_TAG" \
+          -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
+          "images/$PHP_VERSION/cli"
 
       - name: Log Docker images
         run: docker images
 
       - name: Push Docker image
-        run: docker push $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG
+        run: docker push "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG"
 
       - name: Push image as latest
         if: ${{ env.PHP_LATEST == env.PHP_VERSION }}
         run: |
-          docker image tag $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG $PACKAGE_REGISTRY/cli:latest$PR_TAG
-          docker push $PACKAGE_REGISTRY/cli:latest$PR_TAG
+          docker image tag "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" "$PACKAGE_REGISTRY/cli:latest$PR_TAG"
+          docker push "$PACKAGE_REGISTRY/cli:latest$PR_TAG"

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -36,6 +36,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   build-php-images:
@@ -48,10 +52,14 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.2'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Login to the package registry
         run: |
@@ -80,6 +88,8 @@ jobs:
     strategy:
       matrix:
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+    permissions:
+      contents: read
 
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -88,6 +98,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Login to the package registry
         run: |

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -76,23 +76,28 @@ jobs:
 
       - name: Login to the package registry
         run: |
-          echo "$REGISTRY_PASSWORD" | docker login $PACKAGE_REGISTRY_HOST -u "$REGISTRY_USERNAME" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build Docker image
-        run: docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG images/$PHP_VERSION/php
+        run: |
+          docker build \
+          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+          --build-arg PR_TAG="$PR_TAG" \
+          -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
+          "images/$PHP_VERSION/php"
 
       - name: Log Docker images
         run: docker images
 
       - name: Push Docker image
-        run: docker push $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG
+        run: docker push "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG"
 
       - name: Push image as latest
         if: ${{ env.PHP_LATEST == env.PHP_VERSION }}
         run: |
-          docker image tag $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG $PACKAGE_REGISTRY/php:latest$PR_TAG
+          docker image tag "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" "$PACKAGE_REGISTRY/php:latest$PR_TAG"
           docker images
-          docker push $PACKAGE_REGISTRY/php:latest$PR_TAG
+          docker push "$PACKAGE_REGISTRY/php:latest$PR_TAG"
 
   build-cli-images:
     name: CLI on PHP ${{ matrix.php }}
@@ -116,19 +121,24 @@ jobs:
 
       - name: Login to the package registry
         run: |
-          echo "$REGISTRY_PASSWORD" | docker login $PACKAGE_REGISTRY_HOST -u "$REGISTRY_USERNAME" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build Docker image
-        run: docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG images/$PHP_VERSION/cli
+        run: |
+          docker build \
+          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+          --build-arg PR_TAG="$PR_TAG" \
+          -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
+          "images/$PHP_VERSION/cli"
 
       - name: Log Docker images
         run: docker images
 
       - name: Push Docker image
-        run: docker push $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG
+        run: docker push "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG"
 
       - name: Push image as latest
         if: ${{ env.PHP_LATEST == env.PHP_VERSION }}
         run: |
-          docker image tag $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG $PACKAGE_REGISTRY/cli:latest$PR_TAG
-          docker push $PACKAGE_REGISTRY/cli:latest$PR_TAG
+          docker image tag "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" "$PACKAGE_REGISTRY/cli:latest$PR_TAG"
+          docker push "$PACKAGE_REGISTRY/cli:latest$PR_TAG"

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -26,15 +26,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   check-for-changes:
     name: Check for uncommitted changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v.2.31.1
@@ -57,10 +65,14 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.2'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Login to the package registry
         run: |
@@ -89,6 +101,8 @@ jobs:
     strategy:
       matrix:
         php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+    permissions:
+      contents: read
 
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -97,6 +111,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Login to the package registry
         run: |

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -81,10 +81,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
-          --build-arg PR_TAG="$PR_TAG" \
-          -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
-          "images/$PHP_VERSION/php"
+            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+            --build-arg PR_TAG="$PR_TAG" \
+            -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
+            "images/$PHP_VERSION/php"
 
       - name: Log Docker images
         run: docker images
@@ -126,10 +126,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
-          --build-arg PR_TAG="$PR_TAG" \
-          -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
-          "images/$PHP_VERSION/cli"
+            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+            --build-arg PR_TAG="$PR_TAG" \
+            -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
+            "images/$PHP_VERSION/cli"
 
       - name: Log Docker images
         run: docker images

--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -85,6 +85,6 @@ jobs:
             github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: '${{ github.event.number }}',
+              issue_number: process.env.ISSUE_NUMBER,
               name: 'props-bot'
             });

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -54,7 +54,7 @@ jobs:
                   filter_triggers: ''
 
             - name: Upload SARIF file
-              uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+              uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
               with:
                   sarif_file: ${{steps.octoscan.outputs.sarif_output}}
                   category: octoscan
@@ -73,16 +73,16 @@ jobs:
                   persist-credentials: false
 
             - name: Install the latest version of uv
-              uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca # v5.2.1
+              uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
 
             # https://github.com/woodruffw/zizmor
             - name: Run zizmor
-              run: uvx zizmor@1.2.2 --format sarif . > results.sarif
+              run: uvx zizmor@1.9.0 --format sarif . > results.sarif
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Upload SARIF file
-              uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+              uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
               with:
                   sarif_file: results.sarif
                   category: zizmor
@@ -103,7 +103,7 @@ jobs:
           uses: boostsecurityio/poutine-action@84c0a0d32e8d57ae12651222be1eb15351429228 # v0.15.2
 
         - name: Upload SARIF file
-          uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+          uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
           with:
               sarif_file: results.sarif
               category: poutine

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -66,6 +66,7 @@ jobs:
       security-events: write
       actions: read
       contents: read
+    timeout-minutes: 10
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -93,6 +94,7 @@ jobs:
     permissions:
       security-events: write
       contents: read
+    timeout-minutes: 10
     steps:
     - name: Checkout repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -10,6 +10,8 @@ jobs:
   # This helps guard against common mistakes including strong type checking for expressions (${{ }}), security checks,
   # `run:` script checking, glob syntax validation, and more.
   #
+  # See https://github.com/rhysd/actionlint.
+  #
   # Performs the following steps:
   # - Checks out the repository.
   # - Runs actionlint.
@@ -26,13 +28,21 @@ jobs:
           persist-credentials: false
           show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-      # actionlint is static checker for GitHub Actions workflow files.
-      # See https://github.com/rhysd/actionlint.
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.7
         with:
           args: "-color -verbose"
 
+  # Runs the Octoscan workflow file scanner.
+  #
+  # Octoscan is a static vulnerability scanner for GitHub action workflows.
+  #
+  # See https://github.com/synacktiv/octoscan.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Runs Octoscan.
+  # - Uploads the results to GitHub Code Scanning.
   octoscan:
     name: Octoscan
     runs-on: ubuntu-latest
@@ -59,6 +69,16 @@ jobs:
           sarif_file: ${{steps.octoscan.outputs.sarif_output}}
           category: octoscan
 
+  # Runs the Zizmor workflow file scanner.
+  #
+  # Zizmor is a static analysis tool for GitHub Actions that can find many common security issues.
+  #
+  # See https://github.com/zizmorcore/zizmor.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Runs Zizmor.
+  # - Uploads the results to GitHub Code Scanning.
   zizmor:
     name: Zizmor
     runs-on: ubuntu-latest
@@ -76,7 +96,6 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
 
-      # https://github.com/woodruffw/zizmor
       - name: Run zizmor
         run: uvx zizmor@1.9.0 --format sarif . > results.sarif
         env:
@@ -88,6 +107,16 @@ jobs:
           sarif_file: results.sarif
           category: zizmor
 
+  # Runs the Poutine workflow file scanner.
+  #
+  # Poutine is a security scanner that detects misconfigurations and vulnerabilities in the build pipelines of a repository.
+  #
+  # See https://github.com/boostsecurityio/poutine.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Runs Poutine.
+  # - Uploads the results to GitHub Code Scanning.
   poutine:
     name: Poutine
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -1,109 +1,109 @@
 name: Lint GitHub Actions workflows
 on:
-    workflow_call:
+  workflow_call:
 
 permissions: {}
 
 jobs:
-    # Runs the actionlint GitHub Action workflow file linter.
-    #
-    # This helps guard against common mistakes including strong type checking for expressions (${{ }}), security checks,
-    # `run:` script checking, glob syntax validation, and more.
-    #
-    # Performs the following steps:
-    # - Checks out the repository.
-    # - Runs actionlint.
-    actionlint:
-        name: Run actionlint
-        runs-on: ubuntu-24.04
-        permissions:
-            contents: read
-        timeout-minutes: 5
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-              with:
-                  persist-credentials: false
-                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+  # Runs the actionlint GitHub Action workflow file linter.
+  #
+  # This helps guard against common mistakes including strong type checking for expressions (${{ }}), security checks,
+  # `run:` script checking, glob syntax validation, and more.
+  #
+  # Performs the following steps:
+  # - Checks out the repository.
+  # - Runs actionlint.
+  actionlint:
+    name: Run actionlint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-            # actionlint is static checker for GitHub Actions workflow files.
-            # See https://github.com/rhysd/actionlint.
-            - name: Run actionlint
-              uses: docker://rhysd/actionlint:1.7.7
-              with:
-                  args: "-color -verbose"
+      # actionlint is static checker for GitHub Actions workflow files.
+      # See https://github.com/rhysd/actionlint.
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.7
+        with:
+          args: "-color -verbose"
 
-    octoscan:
-        name: Octoscan
-        runs-on: ubuntu-latest
-        permissions:
-            security-events: write
-            actions: read
-            contents: read
-        timeout-minutes: 10
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-              with:
-                  persist-credentials: false
+  octoscan:
+    name: Octoscan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-            - name: Run octoscan
-              id: octoscan
-              uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0 # v1.0.0
-              with:
-                  filter_triggers: ''
+      - name: Run octoscan
+        id: octoscan
+        uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0 # v1.0.0
+        with:
+          filter_triggers: ''
 
-            - name: Upload SARIF file
-              uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
-              with:
-                  sarif_file: ${{steps.octoscan.outputs.sarif_output}}
-                  category: octoscan
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        with:
+          sarif_file: ${{steps.octoscan.outputs.sarif_output}}
+          category: octoscan
 
-    zizmor:
-        name: Zizmor
-        runs-on: ubuntu-latest
-        permissions:
-            security-events: write
-            actions: read
-            contents: read
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-              with:
-                  persist-credentials: false
+  zizmor:
+    name: Zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
-            - name: Install the latest version of uv
-              uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
 
-            # https://github.com/woodruffw/zizmor
-            - name: Run zizmor
-              run: uvx zizmor@1.9.0 --format sarif . > results.sarif
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # https://github.com/woodruffw/zizmor
+      - name: Run zizmor
+        run: uvx zizmor@1.9.0 --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Upload SARIF file
-              uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
-              with:
-                  sarif_file: results.sarif
-                  category: zizmor
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+        with:
+          sarif_file: results.sarif
+          category: zizmor
 
-    poutine:
-        name: Poutine
-        runs-on: ubuntu-latest
-        permissions:
-            security-events: write
-            contents: read
-        steps:
-        - name: Checkout repository
-          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-          with:
-              persist-credentials: false
+  poutine:
+    name: Poutine
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
 
-        - name: Run Poutine
-          uses: boostsecurityio/poutine-action@84c0a0d32e8d57ae12651222be1eb15351429228 # v0.15.2
+    - name: Run Poutine
+      uses: boostsecurityio/poutine-action@84c0a0d32e8d57ae12651222be1eb15351429228 # v0.15.2
 
-        - name: Upload SARIF file
-          uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
-          with:
-              sarif_file: results.sarif
-              category: poutine
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@ce28f5bb42b7a9f2c824e633a3f6ee835bab6858 # v3.29.0
+      with:
+        sarif_file: results.sarif
+        category: poutine

--- a/.github/workflows/reusable-workflow-lint.yml
+++ b/.github/workflows/reusable-workflow-lint.yml
@@ -1,0 +1,109 @@
+name: Lint GitHub Actions workflows
+on:
+    workflow_call:
+
+permissions: {}
+
+jobs:
+    # Runs the actionlint GitHub Action workflow file linter.
+    #
+    # This helps guard against common mistakes including strong type checking for expressions (${{ }}), security checks,
+    # `run:` script checking, glob syntax validation, and more.
+    #
+    # Performs the following steps:
+    # - Checks out the repository.
+    # - Runs actionlint.
+    actionlint:
+        name: Run actionlint
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: read
+        timeout-minutes: 5
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  persist-credentials: false
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+            # actionlint is static checker for GitHub Actions workflow files.
+            # See https://github.com/rhysd/actionlint.
+            - name: Run actionlint
+              uses: docker://rhysd/actionlint:1.7.7
+              with:
+                  args: "-color -verbose"
+
+    octoscan:
+        name: Octoscan
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+            actions: read
+            contents: read
+        timeout-minutes: 10
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  persist-credentials: false
+
+            - name: Run octoscan
+              id: octoscan
+              uses: synacktiv/action-octoscan@6b1cf2343893dfb9e5f75652388bd2dc83f456b0 # v1.0.0
+              with:
+                  filter_triggers: ''
+
+            - name: Upload SARIF file
+              uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+              with:
+                  sarif_file: ${{steps.octoscan.outputs.sarif_output}}
+                  category: octoscan
+
+    zizmor:
+        name: Zizmor
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+            actions: read
+            contents: read
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  persist-credentials: false
+
+            - name: Install the latest version of uv
+              uses: astral-sh/setup-uv@b5f58b2abc5763ade55e4e9d0fe52cd1ff7979ca # v5.2.1
+
+            # https://github.com/woodruffw/zizmor
+            - name: Run zizmor
+              run: uvx zizmor@1.2.2 --format sarif . > results.sarif
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Upload SARIF file
+              uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+              with:
+                  sarif_file: results.sarif
+                  category: zizmor
+
+    poutine:
+        name: Poutine
+        runs-on: ubuntu-latest
+        permissions:
+            security-events: write
+            contents: read
+        steps:
+        - name: Checkout repository
+          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+          with:
+              persist-credentials: false
+
+        - name: Run Poutine
+          uses: boostsecurityio/poutine-action@84c0a0d32e8d57ae12651222be1eb15351429228 # v0.15.2
+
+        - name: Upload SARIF file
+          uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+          with:
+              sarif_file: results.sarif
+              category: poutine

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,0 +1,36 @@
+name: Lint GitHub Actions workflow files
+
+on:
+    push:
+        branches:
+            - trunk
+        paths:
+            # Only run when changes are made to workflow files.
+            - '.github/workflows/**'
+    pull_request:
+        branches:
+            - trunk
+        paths:
+            # Only run when changes are made to workflow files.
+            - '.github/workflows/**'
+    workflow_dispatch:
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
+jobs:
+    lint:
+        name: Lint GitHub Action files
+        permissions:
+            security-events: write
+            actions: read
+            contents: read
+        uses: ./.github/workflows/reusable-workflow-lint.yml

--- a/.github/workflows/workflow-lint.yml
+++ b/.github/workflows/workflow-lint.yml
@@ -1,36 +1,36 @@
 name: Lint GitHub Actions workflow files
 
 on:
-    push:
-        branches:
-            - trunk
-        paths:
-            # Only run when changes are made to workflow files.
-            - '.github/workflows/**'
-    pull_request:
-        branches:
-            - trunk
-        paths:
-            # Only run when changes are made to workflow files.
-            - '.github/workflows/**'
-    workflow_dispatch:
+  push:
+    branches:
+      - trunk
+    paths:
+      # Only run when changes are made to workflow files.
+      - '.github/workflows/**'
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      # Only run when changes are made to workflow files.
+      - '.github/workflows/**'
+  workflow_dispatch:
 
 # Cancels all previous workflow runs for pull requests that have not completed.
 concurrency:
-    # The concurrency group contains the workflow name and the branch name for pull requests
-    # or the commit hash for any other events.
-    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-    cancel-in-progress: true
+  # The concurrency group contains the workflow name and the branch name for pull requests
+  # or the commit hash for any other events.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
-    lint:
-        name: Lint GitHub Action files
-        permissions:
-            security-events: write
-            actions: read
-            contents: read
-        uses: ./.github/workflows/reusable-workflow-lint.yml
+  lint:
+    name: Lint GitHub Action files
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    uses: ./.github/workflows/reusable-workflow-lint.yml

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -99,10 +99,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
-          --build-arg PR_TAG="$PR_TAG" \
-          -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
-          "images/$PHP_VERSION/php"
+            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+            --build-arg PR_TAG="$PR_TAG" \
+            -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
+            "images/$PHP_VERSION/php"
 
       - name: Log Docker images
         run: docker images
@@ -144,10 +144,10 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
-          --build-arg PR_TAG="$PR_TAG" \
-          -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
-          "images/$PHP_VERSION/cli"
+            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+            --build-arg PR_TAG="$PR_TAG" \
+            -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
+            "images/$PHP_VERSION/cli"
 
       - name: Log Docker images
         run: docker images

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -44,15 +44,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 %%GITHUB%%
   check-for-changes:
     name: Check for uncommitted changes
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v.2.31.1
@@ -75,10 +83,14 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Login to the package registry
         run: |
@@ -107,6 +119,8 @@ jobs:
     strategy:
       matrix:
         php: [ %%PHP_VERSION_LIST%% ]
+    permissions:
+      contents: read
 
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -115,6 +129,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Login to the package registry
         run: |

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -94,23 +94,28 @@ jobs:
 
       - name: Login to the package registry
         run: |
-          echo "$REGISTRY_PASSWORD" | docker login $PACKAGE_REGISTRY_HOST -u "$REGISTRY_USERNAME" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build Docker image
-        run: docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG images/$PHP_VERSION/php
+        run: |
+          docker build \
+          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+          --build-arg PR_TAG="$PR_TAG" \
+          -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
+          "images/$PHP_VERSION/php"
 
       - name: Log Docker images
         run: docker images
 
       - name: Push Docker image
-        run: docker push $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG
+        run: docker push "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG"
 
       - name: Push image as latest
         if: ${{ env.PHP_LATEST == env.PHP_VERSION }}
         run: |
-          docker image tag $PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG $PACKAGE_REGISTRY/php:latest$PR_TAG
+          docker image tag "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" "$PACKAGE_REGISTRY/php:latest$PR_TAG"
           docker images
-          docker push $PACKAGE_REGISTRY/php:latest$PR_TAG
+          docker push "$PACKAGE_REGISTRY/php:latest$PR_TAG"
 
   build-cli-images:
     name: CLI on PHP ${{ matrix.php }}
@@ -134,19 +139,24 @@ jobs:
 
       - name: Login to the package registry
         run: |
-          echo "$REGISTRY_PASSWORD" | docker login $PACKAGE_REGISTRY_HOST -u "$REGISTRY_USERNAME" --password-stdin
+          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build Docker image
-        run: docker build --build-arg PACKAGE_REGISTRY=$PACKAGE_REGISTRY --build-arg PR_TAG=$PR_TAG -t $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG images/$PHP_VERSION/cli
+        run: |
+          docker build \
+          --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
+          --build-arg PR_TAG="$PR_TAG" \
+          -t "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" \
+          "images/$PHP_VERSION/cli"
 
       - name: Log Docker images
         run: docker images
 
       - name: Push Docker image
-        run: docker push $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG
+        run: docker push "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG"
 
       - name: Push image as latest
         if: ${{ env.PHP_LATEST == env.PHP_VERSION }}
         run: |
-          docker image tag $PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG $PACKAGE_REGISTRY/cli:latest$PR_TAG
-          docker push $PACKAGE_REGISTRY/cli:latest$PR_TAG
+          docker image tag "$PACKAGE_REGISTRY/cli:$PHP_VERSION-fpm$PR_TAG" "$PACKAGE_REGISTRY/cli:latest$PR_TAG"
+          docker push "$PACKAGE_REGISTRY/cli:latest$PR_TAG"


### PR DESCRIPTION
* Disabled default permissions for all scopes across multiple workflows
* Added `persist-credentials: false` to checkout steps to prevent unnecessary credential persistence
* Removed use of GitHub Action expression usage within scripts
* Added a reusable workflow to lint workflow files using Actionlint, Octoscan, Zizmor, and Poutine
* Ensured all environment variables are quoted to prevent word splitting

## Todo

* Decide if we want to keep Octoscan, Zizmor, and Poutine