### PR TITLE
Fix the PHP 7.2 build on Debian 10.

### DIFF
--- a/images/7.2/php/Dockerfile
+++ b/images/7.2/php/Dockerfile
@@ -15,6 +15,10 @@ ENV COMPOSER_HOME /tmp
 # install the PHP extensions we need
 RUN set -ex; \
 	\
+	sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list; \
+	sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list; \
+	sed -i '/buster-updates/d' /etc/apt/sources.list; \
+	\
 	apt-get update; \
 	\
 	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \

--- a/update.php
+++ b/update.php
@@ -392,6 +392,12 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 					if ( $version == '7.0' ) {
 						$install_extensions .= "echo 'deb http://archive.debian.org/debian stretch main contrib non-free' | tee /etc/apt/sources.list; \\\n\t\\\n\t";
 					}
+					// Debian 10/buster was moved to archive.debian.org in March 2024. See https://lists.debian.org/debian-devel-announce/2024/03/msg00003.html.
+					if ( $version == '7.2' ) {
+						$install_extensions .= "sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list; \\\n\t";
+						$install_extensions .= "sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list; \\\n\t";
+						$install_extensions .= "sed -i '/buster-updates/d' /etc/apt/sources.list; \\\n\t\\\n\t";
+					}
 
 					$install_extensions .= "apt-get update; \\\n\t\\\n\tapt-get install -y --no-install-recommends " . implode( ' ', $config['apt'] ) . ";";
 


### PR DESCRIPTION
As seen in the workflow runs of #172 the PHP 7.2 build is failing because the Debian 10 packages have moved to the archive. Previously: #106.