### PR TITLE
Sorting xdebug problems

### DIFF
--- a/entrypoint/common.sh
+++ b/entrypoint/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.2/php/common.sh
+++ b/images/5.2/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.3/php/common.sh
+++ b/images/5.3/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.4/php/common.sh
+++ b/images/5.4/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.5/php/common.sh
+++ b/images/5.5/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.6.20/php/common.sh
+++ b/images/5.6.20/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.6/php/common.sh
+++ b/images/5.6/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.0/php/common.sh
+++ b/images/7.0/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.1/php/common.sh
+++ b/images/7.1/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.2/php/common.sh
+++ b/images/7.2/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.3/php/common.sh
+++ b/images/7.3/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.4/php/common.sh
+++ b/images/7.4/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.0/php/common.sh
+++ b/images/8.0/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.1/php/common.sh
+++ b/images/8.1/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.2/php/common.sh
+++ b/images/8.2/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.3/php/common.sh
+++ b/images/8.3/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.4/php/common.sh
+++ b/images/8.4/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.5/php/common.sh
+++ b/images/8.5/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
Related to this issue: https://github.com/WordPress/wpdev-docker-images/issues/177

The problem is that it seems that currently is outputting the directory twice and for this reason, xdebug is not being detected as available, hence not enabling it. 