### PR TITLE
Use correct path when checking for PHP extensions

### DIFF
--- a/entrypoint/common.sh
+++ b/entrypoint/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.2/php/common.sh
+++ b/images/5.2/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.3/php/common.sh
+++ b/images/5.3/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.4/php/common.sh
+++ b/images/5.4/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.5/php/common.sh
+++ b/images/5.5/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.6.20/php/common.sh
+++ b/images/5.6.20/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/5.6/php/common.sh
+++ b/images/5.6/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.0/php/common.sh
+++ b/images/7.0/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.1/php/common.sh
+++ b/images/7.1/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.2/php/common.sh
+++ b/images/7.2/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.3/php/common.sh
+++ b/images/7.3/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/7.4/php/common.sh
+++ b/images/7.4/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.0/php/common.sh
+++ b/images/8.0/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.1/php/common.sh
+++ b/images/8.1/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.2/php/common.sh
+++ b/images/8.2/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.3/php/common.sh
+++ b/images/8.3/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.4/php/common.sh
+++ b/images/8.4/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1

--- a/images/8.5/php/common.sh
+++ b/images/8.5/php/common.sh
@@ -4,7 +4,7 @@ set -e
 # Check if an extension is available
 extension_available() {
 	local ext=$1
-	if [ -f "/usr/local/lib/php/extensions/no-debug-non-zts-$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
+	if [ -f "/usr/local/lib/php/extensions/$(php -r 'echo PHP_EXTENSION_DIR;' | xargs basename)/${ext}.so" ]; then
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
Creating this from #178 because the repository does not currently support building test images from forks (see #179).

Fixes #177.