### PR TITLE
ImageMagick Temporary Solution

### DIFF
--- a/images/8.3/php/Dockerfile
+++ b/images/8.3/php/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	\
-	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \
+	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip ghostscript libonig-dev locales sudo rsync libxslt-dev libicu-dev git; \
 	apt-get upgrade openssl -y; \
 	update-ca-certificates --fresh; \
 	sed -i 's/^# *\(\(ru_RU\|fr_FR\|de_DE\|es_ES\|ja_JP\).UTF-8\)/\1/' /etc/locale.gen; \
@@ -26,6 +26,14 @@ RUN set -ex; \
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	\
+	git clone https://github.com/ImageMagick/ImageMagick6.git ImageMagick6; \
+	cd ImageMagick6; \
+	./configure; \
+	make; \
+	make install; \
+	cd ..; \
+	rm -rf ImageMagick6; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.4/php/Dockerfile
+++ b/images/8.4/php/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	\
-	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync libxslt-dev git; \
+	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip ghostscript libonig-dev locales sudo rsync libxslt-dev libicu-dev git; \
 	apt-get upgrade openssl -y; \
 	update-ca-certificates --fresh; \
 	sed -i 's/^# *\(\(ru_RU\|fr_FR\|de_DE\|es_ES\|ja_JP\).UTF-8\)/\1/' /etc/locale.gen; \
@@ -26,6 +26,14 @@ RUN set -ex; \
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
 	docker-php-ext-install gd opcache mysqli zip exif intl mbstring xml xsl; \
+	\
+	git clone https://github.com/ImageMagick/ImageMagick6.git ImageMagick6; \
+	cd ImageMagick6; \
+	./configure; \
+	make; \
+	make install; \
+	cd ..; \
+	rm -rf ImageMagick6; \
 	\
 	pecl install memcached-3.3.0; \
 	pecl install xdebug-3.4.0; \

--- a/images/8.5/php/Dockerfile
+++ b/images/8.5/php/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
 	\
 	apt-get update; \
 	\
-	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip libmagickwand-dev ghostscript libonig-dev locales sudo rsync git; \
+	apt-get install -y --no-install-recommends libjpeg-dev libpng-dev libwebp-dev libzip-dev libssl-dev libmemcached-dev unzip ghostscript libonig-dev locales sudo rsync libicu-dev git; \
 	apt-get upgrade openssl -y; \
 	update-ca-certificates --fresh; \
 	sed -i 's/^# *\(\(ru_RU\|fr_FR\|de_DE\|es_ES\|ja_JP\).UTF-8\)/\1/' /etc/locale.gen; \
@@ -26,6 +26,14 @@ RUN set -ex; \
 	docker-php-ext-configure gd --enable-gd --with-jpeg=/usr --with-webp=/usr; \
 	\
 	docker-php-ext-install gd mysqli zip exif intl mbstring; \
+	\
+	git clone https://github.com/ImageMagick/ImageMagick6.git ImageMagick6; \
+	cd ImageMagick6; \
+	./configure; \
+	make; \
+	make install; \
+	cd ..; \
+	rm -rf ImageMagick6; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/update.php
+++ b/update.php
@@ -114,7 +114,7 @@ $php_versions = array(
 	'8.3' => array(
 		'php' => array(
 			'base_name'       => 'php:8.3-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev', 'libicu-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
@@ -128,7 +128,7 @@ $php_versions = array(
 	'8.4' => array(
 		'php' => array(
 			'base_name'       => 'php:8.4-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev', 'libicu-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
 			'pecl_extensions' => array( 'memcached-3.3.0', 'xdebug-3.4.0', 'imagick' ),
 			'composer'        => true,
@@ -142,7 +142,7 @@ $php_versions = array(
 	'8.5' => array(
 		'php' => array(
 			'base_name'       => 'php:8.5-rc-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync' ),
+			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libicu-dev' ),
 			'extensions'      => array( 'gd', 'mysqli', 'zip', 'exif', 'intl', 'mbstring' ),
 			'pecl_extensions' => array(),
 			'composer'        => true,
@@ -439,6 +439,19 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 				if ( $config['extensions'] ) {
 					$install_extensions .= " \\\n\t\\\n\t";
 					$install_extensions .= "docker-php-ext-install " . implode( ' ', $config['extensions'] ) . ";";
+				}
+
+				if ( in_array( 'libicu-dev', $config['apt'], true ) ) {
+					if ( version_compare( $version, '7.3' ) >= 0 ) {
+						$install_extensions .= " \\\n\t\\\n\t";
+						$install_extensions .= "git clone https://github.com/ImageMagick/ImageMagick6.git ImageMagick6; \\\n\t";
+						$install_extensions .= "cd ImageMagick6; \\\n\t";
+						$install_extensions .= "./configure; \\\n\t";
+						$install_extensions .= "make; \\\n\t";
+						$install_extensions .= "make install; \\\n\t";
+						$install_extensions .= "cd ..; \\\n\t";
+						$install_extensions .= "rm -rf ImageMagick6;";
+					}
 				}
 
 				if ( $config['pecl_extensions'] ) {


### PR DESCRIPTION
After spending a ton of time trying to figure out what would be best for now on the Imagemagick side, assuming that currently we are not support ImageMagick 7.0 and this might take a while with a lot of code changes for for AVIF and other image compression topics I've been working in the past weeks, I believe it would be safer to keep tests up but stay on ImageMagick 6.9

This patch provides this for the 3 images that are not using the `bullseye` flavor.

This changes:
1. Not adding `libmagickwand-dev` by default from trixie
2. Adding it via github (there is a specific repo that stays on ImageMagick6)