### PR TITLE
Disable SSL by default for newer CLI images

### DIFF
--- a/config/no-ssl.cnf
+++ b/config/no-ssl.cnf
@@ -1,0 +1,13 @@
+# Disables SSL for MySQL client connections.
+#
+# The official database images published by Docker automatically issue a self-signed certificate when initially
+# started. Newer distributions are configured to always require SSL connections. When a self-signed certificate
+# is found in the chain, the connection will be rejected.
+#
+# Because these images are meant to be used for local development only, disabling SSL entirely is a reasonable way to
+# work around this issue without having to generate new certificates using a trusted certificate authority, or adding
+# the custom certificate authority to the trust store of every container using the mysql client to connect to the
+# database.
+#
+[client]
+ssl=0

--- a/images/8.1/cli/Dockerfile
+++ b/images/8.1/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.1/cli/Dockerfile
+++ b/images/8.1/cli/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
-COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
+COPY no-ssl.cnf /etc/mysql/conf.d/no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.1/cli/no-ssl.cnf
+++ b/images/8.1/cli/no-ssl.cnf
@@ -1,0 +1,13 @@
+# Disables SSL for MySQL client connections.
+#
+# The official database images published by Docker automatically issue a self-signed certificate when initially
+# started. Newer distributions are configured to always require SSL connections. When a self-signed certificate
+# is found in the chain, the connection will be rejected.
+#
+# Because these images are meant to be used for local development only, disabling SSL entirely is a reasonable way to
+# work around this issue without having to generate new certificates using a trusted certificate authority, or adding
+# the custom certificate authority to the trust store of every container using the mysql client to connect to the
+# database.
+#
+[client]
+ssl=0

--- a/images/8.2/cli/Dockerfile
+++ b/images/8.2/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.2/cli/Dockerfile
+++ b/images/8.2/cli/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
-COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
+COPY no-ssl.cnf /etc/mysql/conf.d/no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.2/cli/no-ssl.cnf
+++ b/images/8.2/cli/no-ssl.cnf
@@ -1,0 +1,13 @@
+# Disables SSL for MySQL client connections.
+#
+# The official database images published by Docker automatically issue a self-signed certificate when initially
+# started. Newer distributions are configured to always require SSL connections. When a self-signed certificate
+# is found in the chain, the connection will be rejected.
+#
+# Because these images are meant to be used for local development only, disabling SSL entirely is a reasonable way to
+# work around this issue without having to generate new certificates using a trusted certificate authority, or adding
+# the custom certificate authority to the trust store of every container using the mysql client to connect to the
+# database.
+#
+[client]
+ssl=0

--- a/images/8.3/cli/Dockerfile
+++ b/images/8.3/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.3/cli/Dockerfile
+++ b/images/8.3/cli/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
-COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
+COPY no-ssl.cnf /etc/mysql/conf.d/no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.3/cli/no-ssl.cnf
+++ b/images/8.3/cli/no-ssl.cnf
@@ -1,0 +1,13 @@
+# Disables SSL for MySQL client connections.
+#
+# The official database images published by Docker automatically issue a self-signed certificate when initially
+# started. Newer distributions are configured to always require SSL connections. When a self-signed certificate
+# is found in the chain, the connection will be rejected.
+#
+# Because these images are meant to be used for local development only, disabling SSL entirely is a reasonable way to
+# work around this issue without having to generate new certificates using a trusted certificate authority, or adding
+# the custom certificate authority to the trust store of every container using the mysql client to connect to the
+# database.
+#
+[client]
+ssl=0

--- a/images/8.4/cli/Dockerfile
+++ b/images/8.4/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.4/cli/Dockerfile
+++ b/images/8.4/cli/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
-COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
+COPY no-ssl.cnf /etc/mysql/conf.d/no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.4/cli/no-ssl.cnf
+++ b/images/8.4/cli/no-ssl.cnf
@@ -1,0 +1,13 @@
+# Disables SSL for MySQL client connections.
+#
+# The official database images published by Docker automatically issue a self-signed certificate when initially
+# started. Newer distributions are configured to always require SSL connections. When a self-signed certificate
+# is found in the chain, the connection will be rejected.
+#
+# Because these images are meant to be used for local development only, disabling SSL entirely is a reasonable way to
+# work around this issue without having to generate new certificates using a trusted certificate authority, or adding
+# the custom certificate authority to the trust store of every container using the mysql client to connect to the
+# database.
+#
+[client]
+ssl=0

--- a/images/8.5/cli/Dockerfile
+++ b/images/8.5/cli/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
+COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.5/cli/Dockerfile
+++ b/images/8.5/cli/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
-COPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf
+COPY no-ssl.cnf /etc/mysql/conf.d/no-ssl.cnf
 
 RUN chmod +x /entrypoint.sh
 

--- a/images/8.5/cli/no-ssl.cnf
+++ b/images/8.5/cli/no-ssl.cnf
@@ -1,0 +1,13 @@
+# Disables SSL for MySQL client connections.
+#
+# The official database images published by Docker automatically issue a self-signed certificate when initially
+# started. Newer distributions are configured to always require SSL connections. When a self-signed certificate
+# is found in the chain, the connection will be rejected.
+#
+# Because these images are meant to be used for local development only, disabling SSL entirely is a reasonable way to
+# work around this issue without having to generate new certificates using a trusted certificate authority, or adding
+# the custom certificate authority to the trust store of every container using the mysql client to connect to the
+# database.
+#
+[client]
+ssl=0

--- a/templates/Dockerfile-cli.template
+++ b/templates/Dockerfile-cli.template
@@ -24,7 +24,7 @@ RUN set -ex; \
 	wp --allow-root --version;
 
 COPY entrypoint.sh /entrypoint.sh
-
+%%DISABLE_SSL%%
 RUN chmod +x /entrypoint.sh
 
 # WP CLI config

--- a/update.php
+++ b/update.php
@@ -496,9 +496,17 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 				$dockerfile = preg_replace( '|\n%%OLD_PHP%%.*%%/OLD_PHP%%\n|s', '', $dockerfile );
 				$dockerfile = str_replace( '%%MYSQL_CLIENT%%', $config['mysql_client'], $dockerfile );
 				$dockerfile = str_replace( '%%DOWNLOAD_URL%%', $config['download_url'], $dockerfile );
+
+				// Copy the configuration file that disables SSL for the MySQL client.
+				if ( version_compare( $version, '8.1' ) >= 0 && file_exists( "config/no-ssl.cnf" ) ) {
+					copy( "config/no-ssl.cnf", "images/{$version}/{$image}/no-ssl.cnf" );
+					$dockerfile = preg_replace( '|\n%%DISABLE_SSL%%\n|s', "\nCOPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf\n\n", $dockerfile );
+				}
 			} else {
 				// WP-CLI isn't available for this version of PHP.
 				$dockerfile = preg_replace( '|\n%%NEW_PHP%%.*%%/NEW_PHP%%\n|s', '', $dockerfile );
+				$dockerfile = preg_replace( '|\n%%DISABLE_SSL%%\n|s', '', $dockerfile );
+
 			}
 		}
 

--- a/update.php
+++ b/update.php
@@ -500,7 +500,7 @@ foreach ( array_merge( $legacy_php_versions, $php_versions ) as $version => $ima
 				// Copy the configuration file that disables SSL for the MySQL client.
 				if ( version_compare( $version, '8.1' ) >= 0 && file_exists( "config/no-ssl.cnf" ) ) {
 					copy( "config/no-ssl.cnf", "images/{$version}/{$image}/no-ssl.cnf" );
-					$dockerfile = preg_replace( '|\n%%DISABLE_SSL%%\n|s', "\nCOPY /etc/mysql/conf.d/no-ssl.cnf /no-ssl.cnf\n\n", $dockerfile );
+					$dockerfile = preg_replace( '|\n%%DISABLE_SSL%%\n|s', "\nCOPY no-ssl.cnf /etc/mysql/conf.d/no-ssl.cnf\n\n", $dockerfile );
 				}
 			} else {
 				// WP-CLI isn't available for this version of PHP.


### PR DESCRIPTION
Some upstream changes to the official Docker `php` images have broken the ability to use the MySQL client within the `cli` images maintained here to communicate with database containers. This is due to the version of Debian being used within the underlying base image switching from `bullseye` to `trixie`, the latter of which enforces secure SSL certificate chains. 

Because the Docker database images are configured to generate a self-signed certificate when first booted. Because a self-signed certificate is not considered trusted by default, this is causing the connections to be rejected.

Since these images are not meant for use in production environments, disabling SSL for the MySQL client is a reasonable fix.