### PR TITLE
Add path filtering to `pull_request` events

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -15,6 +15,7 @@ on:
       - 'config/**'
       - 'entrypoint/**'
       - 'images/**'
+      - 'templates/workflow.yml-template'
       - '.github/workflows/docker-hub.yml'
   workflow_dispatch:
   # Once weekly On Sundays at 00:00 UTC.

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -10,6 +10,11 @@ name: Build test images
 
 on:
   pull_request:
+    paths:
+      - 'config/**'
+      - 'entrypoint/**'
+      - 'images/**'
+      - '.github/workflows/github-container-registry.yml'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -14,6 +14,7 @@ on:
       - 'config/**'
       - 'entrypoint/**'
       - 'images/**'
+      - 'templates/workflow.yml-template'
       - '.github/workflows/github-container-registry.yml'
   workflow_dispatch:
 

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -28,6 +28,11 @@ name: Build test images
 
 on:
   pull_request:
+    paths:
+      - 'config/**'
+      - 'entrypoint/**'
+      - 'images/**'
+      - '.github/workflows/github-container-registry.yml'
   workflow_dispatch:
 
 env:

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -10,6 +10,7 @@ on:
       - 'config/**'
       - 'entrypoint/**'
       - 'images/**'
+      - 'templates/workflow.yml-template'
       - '.github/workflows/docker-hub.yml'
   workflow_dispatch:
   # Once weekly On Sundays at 00:00 UTC.
@@ -32,6 +33,7 @@ on:
       - 'config/**'
       - 'entrypoint/**'
       - 'images/**'
+      - 'templates/workflow.yml-template'
       - '.github/workflows/github-container-registry.yml'
   workflow_dispatch:
 


### PR DESCRIPTION
This adds path filtering to the workflow responsible for building test images and publishing them to GitHub Container Registry.

Test images don't need to be generated when a pull request will not result in changes to the actual images themselves.