### PR TITLE
Stop pinning `bullseye` for PHP 8.1 & 8.2

### DIFF
--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-bullseye
+FROM php:8.1-fpm
 
 WORKDIR /var/www
 

--- a/images/8.2/php/Dockerfile
+++ b/images/8.2/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-fpm-bullseye
+FROM php:8.2-fpm
 
 WORKDIR /var/www
 

--- a/update.php
+++ b/update.php
@@ -384,11 +384,7 @@ foreach ( $php_versions as $version => $images ) {
 		$dockerfile = str_replace( '%%VERSION_TAG%%', $version_tag, $dockerfile );
 
 		if ( $image === 'php' ) {
-            // Temporarily enforce using an image that is correctly installing `libmemcached-dev`.
 			$current_base_name = $config['base_name'];
-			if ( in_array( $config['base_name'], array( 'php:8.1-fpm', 'php:8.2-fpm' ) ) ) {
-            	$current_base_name = str_replace( '-fpm', '-fpm-bullseye', $current_base_name );
-			}
 
             // Replace tags inside the PHP Dockerfile template.
 			$dockerfile = str_replace( '%%BASE_NAME%%', $current_base_name, $dockerfile );


### PR DESCRIPTION
This removes the pinned `bullseye` version of Debian from the PHP 8.1 & 8.2 images.

The upstream base images have been updated and the underlying container is now using `trixie`, which matches PHP >= 8.3.