### PR TITLE
Move the PHP 7.2 & 7.3 images to legacy

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -48,7 +48,7 @@ jobs:
     
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
       fail-fast: false
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -93,7 +93,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
       fail-fast: false
     permissions:
       contents: read

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [ check-for-changes ]
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
       fail-fast: false
     env:
       PHP_VERSION: ${{ matrix.php }}
@@ -106,7 +106,7 @@ jobs:
     needs: build-php-images
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
+        php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
       fail-fast: false
     permissions:
       contents: read

--- a/update.php
+++ b/update.php
@@ -27,34 +27,6 @@ $latest = '8.3';
  * }
  */
 $php_versions = array(
-	'7.2' => array(
-		'php' => array(
-			'base_name'       => 'php:7.2-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'xdebug-3.1.6', 'memcached-3.3.0' ),
-			'composer'        => true,
-		),
-		'phpunit' => 7,
-		'cli' => array(
-			'mysql_client' => 'virtual-mysql-client',
-			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
-		),
-	),
-	'7.3' => array(
-		'php' => array(
-			'base_name'       => 'php:7.3-fpm',
-			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
-			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'xdebug-3.1.6', 'memcached-3.3.0' ),
-			'composer'        => true,
-		),
-		'phpunit' => 7,
-		'cli' => array(
-			'mysql_client' => 'virtual-mysql-client',
-			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
-		),
-	),
 	'7.4' => array(
 		'php' => array(
 			'base_name'       => 'php:7.4-fpm',
@@ -289,6 +261,34 @@ $legacy_php_versions = array(
 			'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
 		),
 	),
+    '7.2' => array(
+        'php' => array(
+            'base_name'       => 'php:7.2-fpm',
+            'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+            'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+            'pecl_extensions' => array( 'imagick', 'xdebug-3.1.6', 'memcached-3.3.0' ),
+            'composer'        => true,
+        ),
+        'phpunit' => 7,
+        'cli' => array(
+            'mysql_client' => 'virtual-mysql-client',
+            'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+        ),
+    ),
+    '7.3' => array(
+        'php' => array(
+            'base_name'       => 'php:7.3-fpm',
+            'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
+            'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
+            'pecl_extensions' => array( 'imagick', 'xdebug-3.1.6', 'memcached-3.3.0' ),
+            'composer'        => true,
+        ),
+        'phpunit' => 7,
+        'cli' => array(
+            'mysql_client' => 'virtual-mysql-client',
+            'download_url' => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+        ),
+    ),
 );
 
 /**


### PR DESCRIPTION
This moves PHP 7.2 & 7.3 to the list of legacy PHP versions, which will stop regenerating these containers every time the workflow runs.

These versions of PHP have not received security updates since November 2020 and December 2021, respectively, so there's no reason to regularly rebuild the images.

Previously: #175, #185.