### PR TITLE
Several improvements to the Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,7 @@ updates:
       default-days: 7
     groups:
       github-actions:
-        patterns:
-          - "*"
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What?
This PR makes a handful of changes to the Dependabot file that is currently configured to prepare updates for the GitHub Actions ecosystem.

- A default `cooldown` period of `7` days is being added.
- The group configuration has been updated to only target `minor` and `patch` updates (major version updates will each get their own isolated pull request).
- The limitation for number of concurrent pull requests at a given time has been raised from `10` to `20` (there are currently 21 unique third-party GitHub Actions being used).
<!-- In a few words, what is the PR actually doing? -->

## Why?
- The `cooldown` value helps to guard against scenarios where a dependency is updated too soon after initial release, which could possibly result in falling victim to a supply chain attack.
- When major releases are mixed in with minor and patch updates, major versions that require broader action to be taken before being merged often block minor and patch updates.

## Use of AI Tools

None.
<!--
You are free to use artificial intelligence (AI) tooling to contribute, but you must disclose what tooling you are using and to what extent a pull request has been authored by AI. It is your responsibility to review and take responsibility for what AI generates. See the WordPress AI Guidelines: <https://make.wordpress.org/ai/handbook/ai-guidelines/>.
-->
