### PR TITLE
Improved Secret handling and other GitHub Actions-related improvements

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -44,6 +44,7 @@ jobs:
     name: PHP ${{ matrix.php }} Image
     runs-on: ubuntu-latest
     
+    environment: 'production'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -51,9 +52,8 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: garypendergast
-      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      
+      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
 
@@ -64,8 +64,10 @@ jobs:
           persist-credentials: false
 
       - name: Login to the package registry
-        run: |
-          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Docker image
         run: |
@@ -92,6 +94,7 @@ jobs:
     name: CLI on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build-php-images
+    environment: 'production'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -102,9 +105,8 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: garypendergast
-      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      
+      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -112,8 +114,10 @@ jobs:
           persist-credentials: false
 
       - name: Login to the package registry
-        run: |
-          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
@@ -103,7 +103,7 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -52,7 +52,6 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
       REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
 
@@ -104,7 +103,6 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
       REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -22,7 +22,6 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  PACKAGE_REGISTRY_HOST:
   PACKAGE_REGISTRY: wordpressdevelop
   PR_TAG:
 

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -71,7 +71,6 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
             --build-arg PR_TAG="$PR_TAG" \
             -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
             "images/$PHP_VERSION/php"

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -22,8 +22,6 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  REGISTRY_USERNAME: garypendergast
-  REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   PACKAGE_REGISTRY_HOST:
   PACKAGE_REGISTRY: wordpressdevelop
   PR_TAG:
@@ -53,6 +51,9 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
+      REGISTRY_USERNAME: garypendergast
+      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      
     permissions:
       contents: read
 
@@ -101,7 +102,9 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-
+      REGISTRY_USERNAME: garypendergast
+      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -43,7 +43,7 @@ jobs:
     name: PHP ${{ matrix.php }} Image
     runs-on: ubuntu-latest
     
-    environment: 'production'
+    environment: 'Docker Hub'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -92,7 +92,7 @@ jobs:
     name: CLI on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build-php-images
-    environment: 'production'
+    environment: 'Docker Hub'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -65,7 +65,6 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
       REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
 
@@ -118,7 +117,6 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
       REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -57,6 +57,7 @@ jobs:
     name: PHP ${{ matrix.php }} Image
     runs-on: ubuntu-latest
     needs: [ check-for-changes ]
+    environment: 'staging'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -64,9 +65,8 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: desrosj
-      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
-      
+      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
 
@@ -77,8 +77,11 @@ jobs:
           persist-credentials: false
 
       - name: Login to the package registry
-        run: |
-          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Docker image
         run: |
@@ -105,6 +108,7 @@ jobs:
     name: CLI on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build-php-images
+    environment: 'staging'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -115,9 +119,8 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: desrosj
-      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
-      
+      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -125,8 +128,11 @@ jobs:
           persist-credentials: false
 
       - name: Login to the package registry
-        run: |
-          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Docker image
         run: |

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -56,7 +56,7 @@ jobs:
     name: PHP ${{ matrix.php }} Image
     runs-on: ubuntu-latest
     needs: [ check-for-changes ]
-    environment: 'staging'
+    environment: 'GitHub Container Registry'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
@@ -106,7 +106,7 @@ jobs:
     name: CLI on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build-php-images
-    environment: 'staging'
+    environment: 'GitHub Container Registry'
     strategy:
       matrix:
         php: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -64,7 +64,7 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
@@ -117,7 +117,7 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -13,7 +13,6 @@ on:
   workflow_dispatch:
 
 env:
-  PACKAGE_REGISTRY_HOST: ghcr.io
   PACKAGE_REGISTRY: ghcr.io/wordpress/wpdev-docker-images
   PR_TAG: -${{ github.event.number }}
 

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -13,8 +13,6 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_USERNAME: desrosj
-  REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
   PACKAGE_REGISTRY_HOST: ghcr.io
   PACKAGE_REGISTRY: ghcr.io/wordpress/wpdev-docker-images
   PR_TAG: -${{ github.event.number }}
@@ -66,6 +64,9 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
+      REGISTRY_USERNAME: desrosj
+      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+      
     permissions:
       contents: read
 
@@ -114,7 +115,9 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '8.3'
-
+      REGISTRY_USERNAME: desrosj
+      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+      
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/github-container-registry.yml
+++ b/.github/workflows/github-container-registry.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
             --build-arg PR_TAG="$PR_TAG" \
             -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
             "images/$PHP_VERSION/php"

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -17,8 +17,6 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  REGISTRY_USERNAME: garypendergast
-  REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   PACKAGE_REGISTRY_HOST:
   PACKAGE_REGISTRY: wordpressdevelop
   PR_TAG:
@@ -31,8 +29,6 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY_USERNAME: desrosj
-  REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
   PACKAGE_REGISTRY_HOST: ghcr.io
   PACKAGE_REGISTRY: ghcr.io/wordpress/wpdev-docker-images
   PR_TAG: -${{ github.event.number }}
@@ -84,6 +80,11 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
+      %%GITHUB%%REGISTRY_USERNAME: desrosj
+      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+      %%/GITHUB%%%%DOCKER_HUB%%REGISTRY_USERNAME: garypendergast
+      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      %%/DOCKER_HUB%%
     permissions:
       contents: read
 
@@ -132,7 +133,11 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
-
+      %%GITHUB%%REGISTRY_USERNAME: desrosj
+      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+      %%/GITHUB%%%%DOCKER_HUB%%REGISTRY_USERNAME: garypendergast
+      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      %%/DOCKER_HUB%%
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -80,7 +80,6 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
       REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
 
@@ -133,7 +132,6 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
       REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
-      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -100,7 +100,6 @@ jobs:
       - name: Build Docker image
         run: |
           docker build \
-            --build-arg PACKAGE_REGISTRY="$PACKAGE_REGISTRY" \
             --build-arg PR_TAG="$PR_TAG" \
             -t "$PACKAGE_REGISTRY/php:$PHP_VERSION-fpm$PR_TAG" \
             "images/$PHP_VERSION/php"

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -71,7 +71,7 @@ jobs:
     name: PHP ${{ matrix.php }} Image
     runs-on: ubuntu-latest
     %%GITHUB%%needs: [ check-for-changes ]%%/GITHUB%%
-    environment: '%%GITHUB%%staging%%/GITHUB%%%%DOCKER_HUB%%production%%/DOCKER_HUB%%'
+    environment: '%%GITHUB%%GitHub Container Registry%%/GITHUB%%%%DOCKER_HUB%%Docker Hub%%/DOCKER_HUB%%'
     strategy:
       matrix:
         php: [ %%PHP_VERSION_LIST%% ]
@@ -121,7 +121,7 @@ jobs:
     name: CLI on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build-php-images
-    environment: '%%GITHUB%%staging%%/GITHUB%%%%DOCKER_HUB%%production%%/DOCKER_HUB%%'
+    environment: '%%GITHUB%%GitHub Container Registry%%/GITHUB%%%%DOCKER_HUB%%Docker Hub%%/DOCKER_HUB%%'
     strategy:
       matrix:
         php: [ %%PHP_VERSION_LIST%% ]

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -79,7 +79,7 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
-      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
@@ -132,7 +132,7 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
-      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -17,7 +17,6 @@ on:
     - cron: '0 0 * * 0'
 
 env:
-  PACKAGE_REGISTRY_HOST:
   PACKAGE_REGISTRY: wordpressdevelop
   PR_TAG:
 %%/DOCKER_HUB%%
@@ -29,7 +28,6 @@ on:
   workflow_dispatch:
 
 env:
-  PACKAGE_REGISTRY_HOST: ghcr.io
   PACKAGE_REGISTRY: ghcr.io/wordpress/wpdev-docker-images
   PR_TAG: -${{ github.event.number }}
 %%/GITHUB%%

--- a/templates/workflow.yml-template
+++ b/templates/workflow.yml-template
@@ -73,6 +73,7 @@ jobs:
     name: PHP ${{ matrix.php }} Image
     runs-on: ubuntu-latest
     %%GITHUB%%needs: [ check-for-changes ]%%/GITHUB%%
+    environment: '%%GITHUB%%staging%%/GITHUB%%%%DOCKER_HUB%%production%%/DOCKER_HUB%%'
     strategy:
       matrix:
         php: [ %%PHP_VERSION_LIST%% ]
@@ -80,11 +81,8 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
-      %%GITHUB%%REGISTRY_USERNAME: desrosj
-      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
-      %%/GITHUB%%%%DOCKER_HUB%%REGISTRY_USERNAME: garypendergast
-      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      %%/DOCKER_HUB%%
+      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     permissions:
       contents: read
 
@@ -95,8 +93,11 @@ jobs:
           persist-credentials: false
 
       - name: Login to the package registry
-        run: |
-          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:%%GITHUB%%
+          registry: ghcr.io%%/GITHUB%%
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Docker image
         run: |
@@ -123,6 +124,7 @@ jobs:
     name: CLI on PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     needs: build-php-images
+    environment: '%%GITHUB%%staging%%/GITHUB%%%%DOCKER_HUB%%production%%/DOCKER_HUB%%'
     strategy:
       matrix:
         php: [ %%PHP_VERSION_LIST%% ]
@@ -133,11 +135,8 @@ jobs:
     env:
       PHP_VERSION: ${{ matrix.php }}
       PHP_LATEST: '%%PHP_LATEST%%'
-      %%GITHUB%%REGISTRY_USERNAME: desrosj
-      REGISTRY_PASSWORD: ${{ secrets.GHCR_TOKEN }}
-      %%/GITHUB%%%%DOCKER_HUB%%REGISTRY_USERNAME: garypendergast
-      REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      %%/DOCKER_HUB%%
+      REGISTRY_USERNAME: ${{ var.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_USERNAME }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -145,8 +144,11 @@ jobs:
           persist-credentials: false
 
       - name: Login to the package registry
-        run: |
-          echo "$REGISTRY_PASSWORD" | docker login "$PACKAGE_REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:%%GITHUB%%
+          registry: ghcr.io%%/GITHUB%%
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build Docker image
         run: |


### PR DESCRIPTION
This makes a few changes to how secrets are handled within GitHub Actions workflows:
- The related secrets have been moved into two different environments: `production` for pushing to Docker Hub and `staging` for pushing to GHCR.
- Since the `REGISTRY_USERNAME` value is known (it is shown publicly on the respective registry), this is now an environment variable.
- `REGISTRY_PASSWORD` has been configured as an environment secret.

Also, there is currently a warning is displayed in the GitHub Actions logs:
```
WARNING! Your credentials are stored unencrypted in '/home/runner/.docker/config.json'.
Configure a credential helper to remove this warning. See
https://docs.docker.com/go/credential-store/
```

While the `docker/login-action` action does not implement a true credential store, it does log out immediately after the job completes (which removes any auth-related entries from the `config.json` file), and silences the warning by using `silent: true`. The action also supports configuring This PR switches to utilizing this action instead of manually adding a log out step.

And finally this removes the `PACKAGE_REGISTRY_HOST` environment variable (which was unused), and removes the `PACKAGE_REGISTRY` build argument from the PHP image build commands (this did nothing since the base images are not pulled from WordPress-related sources).