### PR TITLE
Update xDebug to version 3.5.3

### DIFF
--- a/images/8.0/php/Dockerfile
+++ b/images/8.0/php/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
 	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	pecl install memcached-3.4.0; \
-	pecl install xdebug-3.5.1; \
+	pecl install xdebug-3.5.3; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.1/php/Dockerfile
+++ b/images/8.1/php/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
 	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	pecl install memcached-3.4.0; \
-	pecl install xdebug-3.5.1; \
+	pecl install xdebug-3.5.3; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.2/php/Dockerfile
+++ b/images/8.2/php/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
 	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	pecl install memcached-3.4.0; \
-	pecl install xdebug-3.5.1; \
+	pecl install xdebug-3.5.3; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.3/php/Dockerfile
+++ b/images/8.3/php/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
 	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	pecl install memcached-3.4.0; \
-	pecl install xdebug-3.5.1; \
+	pecl install xdebug-3.5.3; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.4/php/Dockerfile
+++ b/images/8.4/php/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
 	pecl install imagick; \
 	docker-php-ext-enable imagick; \
 	pecl install memcached-3.4.0; \
-	pecl install xdebug-3.5.1; \
+	pecl install xdebug-3.5.3; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/images/8.5/php/Dockerfile
+++ b/images/8.5/php/Dockerfile
@@ -30,7 +30,7 @@ RUN set -ex; \
 	pecl install memcached-3.4.0; \
 	pecl install imagick; \
 	docker-php-ext-enable imagick; \
-	pecl install xdebug-3.5.1; \
+	pecl install xdebug-3.5.3; \
 	\
 	curl --silent --fail --location --retry 3 --output /tmp/installer.php --url https://getcomposer.org/installer; \
 	curl --silent --fail --location --retry 3 --output /tmp/installer.sig --url https://composer.github.io/installer.sig; \

--- a/update.php
+++ b/update.php
@@ -43,7 +43,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.0-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.1' ),
+			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.3' ),
 			'composer'        => true,
 		),
 		'cli' => array(
@@ -56,7 +56,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.1-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.1' ),
+			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.3' ),
 			'composer'        => true,
 		),
 		'cli' => array(
@@ -69,7 +69,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.2-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libzip-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.1' ),
+			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.3' ),
 			'composer'        => true,
 		),
 		'cli' => array(
@@ -82,7 +82,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.3-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libavif-dev', 'libaom-dev', 'libheif-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.1' ),
+			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.3' ),
 			'composer'        => true,
 		),
 		'cli' => array(
@@ -95,7 +95,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.4-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libavif-dev', 'libaom-dev', 'libdav1d-dev', 'libheif-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync', 'libxslt-dev' ),
 			'extensions'      => array( 'gd', 'opcache', 'mysqli', 'zip', 'exif', 'intl', 'mbstring', 'xml', 'xsl' ),
-			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.1' ),
+			'pecl_extensions' => array( 'imagick', 'memcached-3.4.0', 'xdebug-3.5.3' ),
 			'composer'        => true,
 		),
 		'cli' => array(
@@ -108,7 +108,7 @@ $php_versions = array(
 			'base_name'       => 'php:8.5-fpm',
 			'apt'             => array( 'libjpeg-dev', 'libpng-dev', 'libwebp-dev', 'libavif-dev', 'libaom-dev', 'libdav1d-dev', 'libheif-dev', 'libzip-dev', 'libssl-dev', 'libmemcached-dev', 'unzip', 'libmagickwand-dev', 'ghostscript', 'libonig-dev', 'locales', 'sudo', 'rsync' ),
 			'extensions'      => array( 'gd', 'mysqli', 'zip', 'exif', 'intl', 'mbstring' ),
-			'pecl_extensions' => array( 'memcached-3.4.0', 'imagick', 'xdebug-3.5.1' ),
+			'pecl_extensions' => array( 'memcached-3.4.0', 'imagick', 'xdebug-3.5.3' ),
 			'composer'        => true,
 		),
 		'cli' => array(


### PR DESCRIPTION
This updates xDebug to version 3.5.3 for each container running modern xDebug.

[Release notes](https://xdebug.org/updates#x_3_5_3).